### PR TITLE
merge jvm-puppet-0.1.x branch into master

### DIFF
--- a/configs/jvm-puppet/config/bootstrap.cfg
+++ b/configs/jvm-puppet/config/bootstrap.cfg
@@ -2,3 +2,4 @@ puppetlabs.enterprise.master.master-service/pe-master-service
 puppetlabs.master.services.handler.request-handler-service/request-handler-service
 puppetlabs.master.services.jruby.jruby-puppet-service/jruby-puppet-pooled-service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+puppetlabs.master.services.config.jvm-puppet-config-service/jvm-puppet-config-service

--- a/configs/jvm-puppet/jvm-puppet.clj
+++ b/configs/jvm-puppet/jvm-puppet.clj
@@ -1,8 +1,8 @@
-(defproject puppetlabs.packages/jvm-puppet "0.1.1-SNAPSHOT"
+(defproject puppetlabs.packages/jvm-puppet "0.1.1"
   :description "Release artifacts for jvm-puppet"
   :pedantic? :abort
-  :dependencies [[puppetlabs/jvm-puppet "0.1.0"]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.3.4"]]
+  :dependencies [[puppetlabs/jvm-puppet "0.1.1"]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.5.1"]]
 
   :uberjar-name "jvm-puppet-release.jar"
 


### PR DESCRIPTION
Branched off of jvm-puppet-0.1.x, rebased onto master, and resolved merge conflicts.
