### PR TITLE
Support passing NEXUS_VERSION on Jenkins slave.

### DIFF
--- a/configs/jvm-puppet/jvm-puppet.clj
+++ b/configs/jvm-puppet/jvm-puppet.clj
@@ -1,4 +1,4 @@
-(def jvm-puppet-version (or (System/getenv "JVMPUPPET_NEXUS_VERSION") "0.1.1"))
+(def jvm-puppet-version (or (System/getenv "NEXUS_VERSION") "0.1.1"))
 
 (defproject puppetlabs.packages/jvm-puppet jvm-puppet-version
   :description "Release artifacts for jvm-puppet"
@@ -6,6 +6,7 @@
   :dependencies [[puppetlabs/jvm-puppet ~jvm-puppet-version]
                  [puppetlabs/trapperkeeper-webserver-jetty9 "0.5.1"]]
 
+  :nexus-version ~jvm-puppet-version
   :uberjar-name "jvm-puppet-release.jar"
 
   :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]

--- a/configs/pe-jvm-puppet/pe-jvm-puppet.clj
+++ b/configs/pe-jvm-puppet/pe-jvm-puppet.clj
@@ -1,4 +1,4 @@
-(def jvm-puppet-version (or (System/getenv "JVMPUPPET_NEXUS_VERSION") "0.1.1"))
+(def jvm-puppet-version (or (System/getenv "NEXUS_VERSION") "0.1.1"))
 
 (defproject puppetlabs.packages/pe-jvm-puppet jvm-puppet-version
   :description "Release artifacts for pe-jvm-puppet"
@@ -6,6 +6,7 @@
   :dependencies [[puppetlabs/jvm-puppet ~jvm-puppet-version]
                  [puppetlabs/trapperkeeper-webserver-jetty9 "0.3.4"]]
 
+  :nexus-version ~jvm-puppet-version
   :uberjar-name "jvm-puppet-release.jar"
 
   :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -360,6 +360,7 @@ Bundled packages: %s
                               (:description lein-project)
                               (deputils/generate-manifest-string lein-project))
        :uberjar-name  (:uberjar-name lein-project)
+       :nexus-version (:nexus-version lein-project)
        :is-pe-build   (format "%s" (= (get-local-ezbake-var lein-project :build-type "foss") "pe"))})))
 
 (defn usage

--- a/staging-templates/project_data.yaml.mustache
+++ b/staging-templates/project_data.yaml.mustache
@@ -41,3 +41,4 @@ gem_require_path:
 gem_test_files:
 gem_executables:
 gem_default_executables:
+nexus_version: {{{nexus-version}}}

--- a/template/global/tasks/uber_jar.rake
+++ b/template/global/tasks/uber_jar.rake
@@ -1,9 +1,22 @@
 # Task for building the jar file containing all the things
 
+project_data_file = File.join(RAKE_ROOT, 'ext', 'project_data.yaml')
+
+if File.exist?(project_data_file)
+  begin
+    require 'yaml'
+    @project_data ||= YAML.load_file(project_data_file)
+  rescue Exception => e
+    STDERR.puts "Unable to load yaml from #{project_data_file}:"
+    raise e
+  end
+end
+
 desc "Build the uberjar"
 task :uberjar => [  ] do
+  @nexus_version = @project_data['nexus_version']
   if `which lein`
-    sh "lein -U uberjar"
+    sh "export NEXUS_VERSION=#{@nexus_version}; lein -U uberjar"
     mv "target/#{EZBake::Config[:uberjar_name]}", EZBake::Config[:uberjar_name]
   else
     puts "You need lein on your system"


### PR DESCRIPTION
The last commit in this branch adds JVMPUPPET_NEXUS_VERSION to allow more
flexible definition of the puppetlabs/jvm-puppet dependency as well as the
jvm-puppet and pe-jvm-puppet lein project versions.

This commit supplements that behavior by generalizing the environment variable
name, adding nexus_version to project_data.yaml and the associated ezbake
generation functions, and invoking that build parameter in the uber_jar.rake
packaging task that ends up being run on a Jenkins slave such that the lein task
sees it.

Signed-off-by: Wayne wayne@puppetlabs.com
