### PR TITLE
(PE-3652) Make JAVA_ARGS configurable

### DIFF
--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -345,7 +345,9 @@ Bundled packages: %s
          :deb-preinst     (quoted-list (get-preinst ezbake-vars upstream-ezbake-configs build-target :debian))
          :redhat-deps     (quoted-list (get-deps upstream-ezbake-configs build-target :redhat))
          :redhat-preinst  (quoted-list (get-preinst ezbake-vars upstream-ezbake-configs build-target :redhat))
-         :terminus-map    termini}))))
+         :terminus-map    termini
+         :java-args       (get-local-ezbake-var lein-project :java-args
+                                                "-Xmx192m")}))))
 
 (defn generate-project-data-yaml
   [lein-project build-target]

--- a/staging-templates/ezbake.rb.mustache
+++ b/staging-templates/ezbake.rb.mustache
@@ -21,5 +21,6 @@ module EZBake
                     :additional_dependencies => [{{{redhat-deps}}}],
                     :additional_preinst => [{{{redhat-preinst}}}],
                  },
+      :java_args => '{{{java-args}}}',
   }
 end

--- a/template/foss/ext/default.erb
+++ b/template/foss/ext/default.erb
@@ -6,7 +6,7 @@
 JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="-Xmx192m"
+JAVA_ARGS="<%= EZBake::Config[:java_args] %>"
 
 # These normally shouldn't need to be edited if using OS packages
 USER="<%= EZBake::Config[:user] %>"

--- a/template/pe/ext/default.erb
+++ b/template/pe/ext/default.erb
@@ -6,7 +6,7 @@
 JAVA_BIN="/opt/puppet/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="-Xmx192m"
+JAVA_ARGS="<%= EZBake::Config[:java_args] %>"
 
 # These normally shouldn't need to be edited if using OS packages
 USER="<%= EZBake::Config[:user] %>"


### PR DESCRIPTION
As some ezbake projects will have different needs of the jvm, this
commit allows individual projects to override the default JAVA_ARGS set
in the default template for packaging. The override can be set in the
individual project's ezbake config, using the java-args key. If no
java-args are provided, it defaults to "-Xmx192m".
