### PR TITLE
Allow templating project file using command line arguments

### DIFF
--- a/configs/classifier/classifier.clj
+++ b/configs/classifier/classifier.clj
@@ -1,7 +1,7 @@
-(defproject puppetlabs.packages/classifier "0.2.4-SNAPSHOT"
+(defproject puppetlabs.packages/classifier "{{{classifier-version}}}"
   :description "Release artifacts for classifier"
   :pedantic? :abort
-  :dependencies [[puppetlabs/classifier "0.2.3"]]
+  :dependencies [[puppetlabs/classifier "{{{classifier-version}}}"]]
 
   :uberjar-name "classifier-release.jar"
 


### PR DESCRIPTION
Any arguments after the first two will be interpreted as variables to be used
in templating the project file. Each argument should be of the form
variable=value. These will be interpolated before the project file is
interpreted by ezbake.
