### PR TITLE
(maint) Update and correct rpm versioning

### DIFF
--- a/template/foss/ext/redhat/ezbake.spec.erb
+++ b/template/foss/ext/redhat/ezbake.spec.erb
@@ -62,8 +62,8 @@ Group: Development/Libraries
 Summary: Termini for <%= EZBake::Config[:project] %>
 Requires: puppet
 <% EZBake::Config[:terminus_info].each do |proj_name, info| -%>
-Obsoletes: <%= proj_name -%>-terminus < <%= info[:version] %>
-Provides:  <%= proj_name -%>-terminus >= <%= info[:version] %>
+Obsoletes: <%= proj_name -%>-terminus < <%= info[:version].gsub('-', '.') %>
+Provides:  <%= proj_name -%>-terminus >= <%= info[:version].gsub('-', '.') %>
 <% end -%>
 
 %description termini

--- a/template/pe/ext/redhat/ezbake.spec.erb
+++ b/template/pe/ext/redhat/ezbake.spec.erb
@@ -79,8 +79,8 @@ Group: Development/Libraries
 Summary: Termini for <%= EZBake::Config[:project] %>
 Requires: pe-puppet
 <% EZBake::Config[:terminus_info].each do |proj_name, info| -%>
-Obsoletes: <%= proj_name -%>-terminus < <%= info[:version] %>
-Provides:  <%= proj_name -%>-terminus >= <%= info[:version] %>
+Obsoletes: <%= proj_name -%>-terminus < <%= info[:version].gsub('-', '.') %>
+Provides:  <%= proj_name -%>-terminus >= <%= info[:version].gsub('-', '.') %>
 <% end -%>
 
 %description termini


### PR DESCRIPTION
The introduction of maven timestamps into the version string exposed a couple of bugs in the current rpm spec file, which this PR attempts to resolve.
