### PR TITLE
Update jvm-puppet project configs.

### DIFF
--- a/configs/jvm-puppet/jvm-puppet.clj
+++ b/configs/jvm-puppet/jvm-puppet.clj
@@ -1,9 +1,7 @@
-(def jvm-puppet-version (or (System/getenv "JVMPUPPET_NEXUS_VERSION") "0.1.2-SNAPSHOT"))
-
-(defproject puppetlabs.packages/jvm-puppet jvm-puppet-version
+(defproject puppetlabs.packages/jvm-puppet "{{{jvm-puppet-version}}}"
   :description "Release artifacts for jvm-puppet"
   :pedantic? :abort
-  :dependencies [[puppetlabs/jvm-puppet ~jvm-puppet-version]
+  :dependencies [[puppetlabs/jvm-puppet "{{{jvm-puppet-version}}}"]
                  [puppetlabs/trapperkeeper-webserver-jetty9 "0.5.1"]]
 
   :uberjar-name "jvm-puppet-release.jar"

--- a/configs/pe-jvm-puppet/pe-jvm-puppet.clj
+++ b/configs/pe-jvm-puppet/pe-jvm-puppet.clj
@@ -1,9 +1,7 @@
-(def jvm-puppet-version (or (System/getenv "JVMPUPPET_NEXUS_VERSION") "0.1.2-SNAPSHOT"))
-
-(defproject puppetlabs.packages/pe-jvm-puppet jvm-puppet-version
+(defproject puppetlabs.packages/pe-jvm-puppet "{{{pe-jvm-puppet-version}}}"
   :description "Release artifacts for pe-jvm-puppet"
   :pedantic? :abort
-  :dependencies [[puppetlabs/jvm-puppet ~jvm-puppet-version]
+  :dependencies [[puppetlabs/jvm-puppet "{{{pe-jvm-puppet-version}}}"]
                  [puppetlabs/trapperkeeper-webserver-jetty9 "0.3.4"]]
 
   :uberjar-name "jvm-puppet-release.jar"


### PR DESCRIPTION
jvm-puppet project configs now take jvm-puppet-version (pe-jvm-puppet-version
for pe-jvm-puppet) key=value parameters to simplify version specification in CI
and development.

Signed-off-by: Wayne wayne@puppetlabs.com
