### PR TITLE
(maint) Remove EOL cows from foss build_defaults.yaml

### DIFF
--- a/template/foss/ext/build_defaults.yaml
+++ b/template/foss/ext/build_defaults.yaml
@@ -2,7 +2,7 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 default_cow: 'base-squeeze-i386.cow'
-cows: 'base-precise-i386.cow base-quantal-i386.cow base-raring-i386.cow base-saucy-i386.cow base-trusty-i386.cow base-stable-i386.cow base-wheezy-i386.cow base-testing-i386.cow'
+cows: 'base-precise-i386.cow base-saucy-i386.cow base-trusty-i386.cow base-stable-i386.cow base-wheezy-i386.cow base-testing-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_name: 'info@puppetlabs.com'


### PR DESCRIPTION
Ubuntu raring and quantal are both EOL, so let's not build anymore
packages for them.
