### PR TITLE
(RE-2133) Update Makefile.erb.

### DIFF
--- a/template/global/Makefile.erb
+++ b/template/global/Makefile.erb
@@ -26,3 +26,33 @@ install-<%= EZBake::Config[:project] %>-termini:
 <% end -%>
 <% end -%>
 <% end -%>
+
+install-rpm-sysv-init: install-rpm-preinst
+	install -d -m 0755 "$(DESTDIR)$(initdir)"
+	install -m 0755 ext/redhat/init "$(DESTDIR)$(initdir)/<%= EZBake::Config[:real_name] %>"
+	install -d -m 0755 "$(DESTDIR)$(defaultsdir)"
+	install -m 0644 ext/default "$(DESTDIR)$(defaultsdir)/<%= EZBake::Config[:real_name] %>"
+	install -d -m 0755 "$(DESTDIR)$(rundir)"
+
+install-rpm-systemd: install-rpm-preinst
+	install -d -m 0755 "$(DESTDIR)$(defaultsdir)"
+	install -m 0644 ext/default "$(DESTDIR)$(defaultsdir)/<%= EZBake::Config[:real_name] %>"
+	install -d -m 0755 "$(DESTDIR)$(unitdir)"
+	install -m 0755 ext/<%= EZBake::Config[:real_name] %>.service "$(DESTDIR)$(unitdir)/<%= EZBake::Config[:project] %>.service"
+
+install-rpm-preinst:
+<% EZBake::Config[:redhat][:additional_preinst].each do |preinst| -%>
+	<%= preinst -%> 
+<% end -%>
+
+install-deb-sysv-init: install-deb-preinst
+	install -d -m 0755 "$(DESTDIR)$(initdir)"
+	install -m 0755 ext/redhat/init "$(DESTDIR)$(initdir)/<%= EZBake::Config[:real_name] %>"
+	install -d -m 0755 "$(DESTDIR)$(defaultsdir)"
+	install -m 0644 ext/default "$(DESTDIR)$(defaultsdir)/<%= EZBake::Config[:real_name] %>"
+	install -d -m 0755 "$(DESTDIR)$(rundir)"
+
+install-deb-preinst:
+<% EZBake::Config[:debian][:additional_preinst].each do |preinst| -%>
+	<%= preinst -%> 
+<% end -%>


### PR DESCRIPTION
Adds install-rpm-sysv-init, install-deb-sysv-init, install-rpm-systemd,
install-rpm-preinst, install-deb-preinst to support install_from_ezbake Beaker
method.

Signed-off-by: Wayne wayne@puppetlabs.com
