### PR TITLE
Updated JVMP Jetty9 dependency to 0.5.2

### DIFF
--- a/configs/jvm-puppet/jvm-puppet.clj
+++ b/configs/jvm-puppet/jvm-puppet.clj
@@ -2,7 +2,7 @@
   :description "Release artifacts for jvm-puppet"
   :pedantic? :abort
   :dependencies [[puppetlabs/jvm-puppet "{{{jvm-puppet-version}}}"]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.5.1"]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.5.2"]]
 
   :uberjar-name "jvm-puppet-release.jar"
 


### PR DESCRIPTION
This commit updates the jvm-puppet project's dependency on
trapperkeeper-webservices-jetty9 to version 0.5.2.
