### PR TITLE
(PE-4427) Use `killproc` in stop init action.

### DIFF
--- a/template/foss/ext/debian/ezbake.init.erb
+++ b/template/foss/ext/debian/ezbake.init.erb
@@ -65,7 +65,7 @@ do_stop()
     #   1 if daemon was already stopped
     #   2 if daemon could not be stopped
     #   other if a failure occurred
-    start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --exec $JAVA_BIN
+    start-stop-daemon --stop --quiet --retry=TERM/10/KILL/5 --pidfile $PIDFILE --exec $JAVA_BIN
     RETVAL="$?"
     [ "$RETVAL" = 2 ] && return 2
     # Many daemons don't delete their pidfiles when they exit.

--- a/template/foss/ext/redhat/init.erb
+++ b/template/foss/ext/redhat/init.erb
@@ -75,12 +75,14 @@ start() {
 stop() {
     echo -n $"Stopping $prog: "
     find_my_pid
-    if [ -s "$PIDFILE" ] ; then
-        kill `cat $PIDFILE`
-    elif [ "$pid" != "" ] ; then
-        kill $pid
+
+    if [ ! -s "$PIDFILE" ] ; then
+      echo $pid > $PIDFILE
     fi
+
+    killproc -p $PIDFILE -d 10s $prog
     retval=$?
+
     [ $retval -eq 0 ] && success $"$base stopped" || failure $"$base stopped"
     echo
     [ $retval -eq 0 ] && rm -f $lockfile $PIDFILE

--- a/template/pe/ext/debian/ezbake.init.erb
+++ b/template/pe/ext/debian/ezbake.init.erb
@@ -65,7 +65,7 @@ do_stop()
     #   1 if daemon was already stopped
     #   2 if daemon could not be stopped
     #   other if a failure occurred
-    start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --exec $JAVA_BIN
+    start-stop-daemon --stop --quiet --retry=TERM/10/KILL/5 --pidfile $PIDFILE --exec $JAVA_BIN
     RETVAL="$?"
     [ "$RETVAL" = 2 ] && return 2
     # Many daemons don't delete their pidfiles when they exit.

--- a/template/pe/ext/redhat/init.erb
+++ b/template/pe/ext/redhat/init.erb
@@ -75,12 +75,14 @@ start() {
 stop() {
     echo -n $"Stopping $prog: "
     find_my_pid
-    if [ -s "$PIDFILE" ] ; then
-        kill `cat $PIDFILE`
-    elif [ "$pid" != "" ] ; then
-        kill $pid
+
+    if [ ! -s "$PIDFILE" ] ; then
+      echo $pid > $PIDFILE
     fi
+
+    killproc -p $PIDFILE -d 10s $prog
     retval=$?
+
     [ $retval -eq 0 ] && success $"$base stopped" || failure $"$base stopped"
     echo
     [ $retval -eq 0 ] && rm -f $lockfile $PIDFILE


### PR DESCRIPTION
`killproc` from /etc/rc.d/init.d/functions will wait the specified amount of
time before performing a SIGKILL of the PIDs in $PIDFILE. Use a hard-coded
30-sec wait after SIGTERM and before SIGKILL since this is how the debian style
package init script behaves.

Signed-off-by: Wayne wayne@puppetlabs.com
