### PR TITLE
Updated PE-JVM Puppet bootstrap.cfg with some extra services

### DIFF
--- a/configs/pe-jvm-puppet/config/bootstrap.cfg
+++ b/configs/pe-jvm-puppet/config/bootstrap.cfg
@@ -1,4 +1,7 @@
-puppetlabs.enterprise.master.master-service/pe-master-service
+puppetlabs.enterprise.master.services.master.master-service/pe-master-service
 puppetlabs.master.services.handler.request-handler-service/request-handler-service
 puppetlabs.master.services.jruby.jruby-puppet-service/jruby-puppet-pooled-service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+puppetlabs.master.services.config.jvm-puppet-config-service/jvm-puppet-config-service
+puppetlabs.master.services.ca.certificate-authority-service/certificate-authority-service
+puppetlabs.enterprise.master.services.jgit.jgit-service/jgit-service


### PR DESCRIPTION
This commit adds the following services to the PE-JVM Puppet
bootstrap.cfg file:
- jvm-puppet-config-service
- certificate-authority-service
- jgit-service

This commit also updates the reference to the pe-master-service to point
to its location in a new namespace.
