### PR TITLE
Bump specify Xmx value in java-args for jvm-puppet

### DIFF
--- a/configs/jvm-puppet/jvm-puppet.clj
+++ b/configs/jvm-puppet/jvm-puppet.clj
@@ -13,5 +13,6 @@
   :ezbake { :user "puppet"
             :group "puppet"
             :build-type "foss"
+            :java-args "-Xmx1g"
             }
   )

--- a/configs/pe-jvm-puppet/pe-jvm-puppet.clj
+++ b/configs/pe-jvm-puppet/pe-jvm-puppet.clj
@@ -2,7 +2,7 @@
   :description "Release artifacts for pe-jvm-puppet"
   :pedantic? :abort
   :dependencies [[puppetlabs/jvm-puppet "{{{pe-jvm-puppet-version}}}"]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.3.4"]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.5.2"]]
 
   :uberjar-name "jvm-puppet-release.jar"
 
@@ -13,5 +13,6 @@
   :ezbake { :user "pe-puppet"
             :group "pe-puppet"
             :build-type "pe"
+            :java-args "-Xmx1g"
             }
   )


### PR DESCRIPTION
Also takes this opportunity to bump the
puppetlabs/trapperkeeper-webserver-jetty9 value in pe-jvm-puppet

Signed-off-by: Wayne wayne@puppetlabs.com
