### PR TITLE
Fix for pe-classifier debian package install

### DIFF
--- a/template/pe/ext/debian/rules.erb
+++ b/template/pe/ext/debian/rules.erb
@@ -8,6 +8,7 @@ rubylibdir=$(shell /opt/puppet/bin/ruby -rrbconfig -e "puts RbConfig::CONFIG['si
 export DESTDIR=$(BUILD_ROOT)
 export prefix=/opt/puppet
 export rubylibdir
+export confdir=/etc/puppetlabs
 
 install/<%= EZBake::Config[:project] %>::
 	echo "PATH IS: ${PATH}"


### PR DESCRIPTION
This sets confdir to /etc/puppetlabs.
