### PR TITLE
Fix error capturing return value in debian pe init script

### DIFF
--- a/template/pe/ext/debian/ezbake.init.erb
+++ b/template/pe/ext/debian/ezbake.init.erb
@@ -65,7 +65,8 @@ do_stop()
     #   1 if daemon was already stopped
     #   2 if daemon could not be stopped
     #   other if a failure occurred
-    start-stop-daemon --stop --quiet --retry=TERM/${SERVICE_STOP_RETRIES}/KILL/5 --pidfile $PIDFILE --exec $JAVA_BIN RETVAL="$?"
+    start-stop-daemon --stop --quiet --retry=TERM/${SERVICE_STOP_RETRIES}/KILL/5 --pidfile $PIDFILE --exec $JAVA_BIN
+    RETVAL="$?"
     [ "$RETVAL" = 2 ] && return 2
     # Many daemons don't delete their pidfiles when they exit.
     rm -f $PIDFILE


### PR DESCRIPTION
Somehow two lines got joined here. The assignment to RETVAL is supposed to be
on its own line to capture the exit code of start-stop-daemon.
