### PR TITLE
(MAINT) Return nonzero exit status if parameters incorrect.

### DIFF
--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -472,7 +472,7 @@ Bundled packages: %s
   (if (>= (count args) 2)
     (let [[action project & template-vars] args]
       (if-not (every? (partial re-find #"=") template-vars)
-        (println "Arguments after the project name are expected to be variable bindings of the form <variable>=<value>")
+        (exit 1 "Arguments after the project name are expected to be variable bindings of the form <variable>=<value>")
         (try
           (ezbake-init action project template-vars)
           (finally


### PR DESCRIPTION
I was seeing runs of ezbake fail when given incorrect arguments in CI. Nonzero exit status is important here.
