### PR TITLE
(PE-5769) Add replaces-pkgs declaration for pe-console-services

### DIFF
--- a/configs/pe-console-services/pe-console-services.clj
+++ b/configs/pe-console-services/pe-console-services.clj
@@ -18,4 +18,5 @@
 
   :ezbake {:user "pe-console-services"
            :group "pe-console-services"
-           :build-type "pe"})
+           :build-type "pe"
+           :replaces-pkgs [{:package "pe-rubycas-server", :version "1.1.17.3"}]})


### PR DESCRIPTION
pe-console-services will include an rbac component, which will replace
~~pe-console-auth and by extension~~, pe-rubycas-server. This commit adds a
replaces-pkgs declaration for each of those packages, at the versions
shipped in PE 3.3.0.
