### PR TITLE
Add default setting required for pe-jvm-puppet

### DIFF
--- a/configs/pe-jvm-puppet/config/conf.d/global.ini
+++ b/configs/pe-jvm-puppet/config/conf.d/global.ini
@@ -3,3 +3,4 @@
 # TODO: this is the paths on default el6 OSS install;
 # this can't be hard-coded like this in the long run
 logging-config = /etc/puppetlabs/jvm-puppet/logback.xml
+hostname = localhost


### PR DESCRIPTION
This commit adds a default hostname for the profiler-service to use as
part of the global config.
