### PR TITLE
(QENG-903) Fix preinsts and install-deb-sysv-init

### DIFF
--- a/template/global/Makefile.erb
+++ b/template/global/Makefile.erb
@@ -42,17 +42,18 @@ install-rpm-systemd: install-rpm-preinst
 
 install-rpm-preinst:
 <% EZBake::Config[:redhat][:additional_preinst].each do |preinst| -%>
-	<%= preinst -%> 
+	<%= preinst %>
 <% end -%>
 
 install-deb-sysv-init: install-deb-preinst
 	install -d -m 0755 "$(DESTDIR)$(initdir)"
-	install -m 0755 ext/redhat/init "$(DESTDIR)$(initdir)/<%= EZBake::Config[:real_name] %>"
+	install -m 0755 ext/debian/<%= EZBake::Config[:real_name] %>.init "$(DESTDIR)$(initdir)/<%= EZBake::Config[:real_name] %>"
 	install -d -m 0755 "$(DESTDIR)$(defaultsdir)"
 	install -m 0644 ext/default "$(DESTDIR)$(defaultsdir)/<%= EZBake::Config[:project] %>"
 	install -d -m 0755 "$(DESTDIR)$(rundir)"
 
 install-deb-preinst:
 <% EZBake::Config[:debian][:additional_preinst].each do |preinst| -%>
-	<%= preinst -%> 
+	<%= preinst %>
 <% end -%>
+


### PR DESCRIPTION
Previously `install-deb-sysv-init` was installing the redhat init script.

Also, `install-deb-preinst` and `install-rpm-preinst` were simply concatenating
the strings in the `:additonal_preinst` which I never noticed until attempting
to install from ezbake on a debian machine. This simple adds a semi colon at the
end of each preinst line.

Signed-off-by: Wayne wayne@puppetlabs.com
