### PR TITLE
Update classifier pkgs' TK jetty9 service dep.

### DIFF
--- a/configs/classifier/classifier.clj
+++ b/configs/classifier/classifier.clj
@@ -2,7 +2,7 @@
   :description "Release artifacts for classifier"
   :pedantic? :abort
   :dependencies [[puppetlabs/classifier "{{{classifier-version}}}"]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.5.1"]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.6.0"]]
 
   :uberjar-name "classifier-release.jar"
 

--- a/configs/pe-classifier/pe-classifier.clj
+++ b/configs/pe-classifier/pe-classifier.clj
@@ -2,7 +2,7 @@
   :description "Release artifacts for classifier"
   :pedantic? :abort
   :dependencies [[puppetlabs/classifier "{{{pe-classifier-version}}}"]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.5.1"]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.6.0"]]
 
   :uberjar-name "classifier-release.jar"
 


### PR DESCRIPTION
Update the TrapperKeeper jetty9 webserver service for classifier and pe-classifier to 0.6.0, which allows multiple webserver configurations to coexist in the same TK stack (necessary for the pe-console-services integration work).
