### PR TITLE
(PE-5446) Update jetty9 dependency for webrouter service config updates

### DIFF
--- a/configs/pe-console-services/pe-console-services.clj
+++ b/configs/pe-console-services/pe-console-services.clj
@@ -7,7 +7,7 @@
                  [puppetlabs/rbac-ui "{{{pe-rbac-ui-version}}}"]
                  ;[puppetlabs/pe-activity-service "{{{pe-classifier-version}}}"]
                  ;[puppetlabs/pe-trapperkeeper-proxy "{{{pe-trapperkeeper-proxy}}}"]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.6.0"]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.7.0"]]
 
   :uberjar-name "console-services-release.jar"
 


### PR DESCRIPTION
This commit updates the jetty9 dependency so that we may use the
deafult-server config option and webrouter service changes for the
pe_console_services.
