### PR TITLE
(maint) Update classifier name in bootstrap.cfgs

### DIFF
--- a/configs/classifier/config/bootstrap.cfg
+++ b/configs/classifier/config/bootstrap.cfg
@@ -1,2 +1,2 @@
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
-puppetlabs.classifier.application/classifier-service
+puppetlabs.classifier.main/classifier-service

--- a/configs/pe-classifier/config/bootstrap.cfg
+++ b/configs/pe-classifier/config/bootstrap.cfg
@@ -1,5 +1,5 @@
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
-puppetlabs.classifier.application/classifier-service
+puppetlabs.classifier.main/classifier-service
 puppetlabs.classifier-ui.service/classifier-ui-service
 puppetlabs.rbac.services.rbac/rbac-service
 puppetlabs.rbac.services.authn/rbac-authn-service

--- a/configs/pe-console-services/config/bootstrap.cfg
+++ b/configs/pe-console-services/config/bootstrap.cfg
@@ -1,6 +1,6 @@
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
 #Classifier
-puppetlabs.classifier.application/classifier-service
+puppetlabs.classifier.main/classifier-service
 #Classifier-UI
 puppetlabs.classifier-ui.service/classifier-ui-service
 #RBAC


### PR DESCRIPTION
The namespace of the classifier's service definition has changed in
version 0.6.0 due to a refactor, so it needs to be updated in
bootstrap.cfgs.
