### PR TITLE
(maint) Make the jetty9 version for console_services a build parameter

### DIFF
--- a/configs/pe-console-services/pe-console-services.clj
+++ b/configs/pe-console-services/pe-console-services.clj
@@ -7,7 +7,7 @@
                  [puppetlabs/rbac-ui "{{{pe-rbac-ui-version}}}"]
                  [puppetlabs/pe-activity-service "{{{pe-activity-service-version}}}"]
                  ;[puppetlabs/pe-trapperkeeper-proxy "{{{pe-trapperkeeper-proxy-version}}}"]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.7.0"]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "{{{trapperkeeper-webserver-jetty9-version}}}"]]
 
   :uberjar-name "console-services-release.jar"
 


### PR DESCRIPTION
This commit makes the version of trapperkeeper-webserver-jetty9 to use
when build pe-console-services a parameter which means that we won't
have to make a commit whenever we would like to bump the version of
jetty9.
