### PR TITLE
(PE-3002) Fix bug if no bin script

### DIFF
--- a/template/foss/ext/redhat/ezbake.spec.erb
+++ b/template/foss/ext/redhat/ezbake.spec.erb
@@ -173,7 +173,7 @@ fi
 %endif
 %config(noreplace) %{_sysconfdir}/%{name}
 %{_sysconfdir}/sysconfig/%{name}
-<% if File.exists?("ext/bin/#{EZBake::Config[:real_name]}") %>
+<% if ! EZBake::Config[:cli_app_files].empty? %>
 %{_bindir}/%{name}
 <% end %>
 %ghost %attr(0755, root, root) %{_rundir}/%{name}


### PR DESCRIPTION
The changes related to supporting CLI apps in ezbake projects
were intended to only create a wrapper bin script if the project
actually provided at least one CLI tool.  However, in the redhat
spec, we were trying to install the bin script even if that
condition hadn't been met.  This commit should fix that issue,
and allow RPMs to be built for projects that don't have any cli
apps.
