### PR TITLE
Bump tk-ws-jetty9 to 0.7.2 for pe-jvm-puppet

### DIFF
--- a/configs/pe-jvm-puppet/pe-jvm-puppet.clj
+++ b/configs/pe-jvm-puppet/pe-jvm-puppet.clj
@@ -2,7 +2,7 @@
   :description "Release artifacts for pe-jvm-puppet"
   :pedantic? :abort
   :dependencies [[puppetlabs/pe-jvm-puppet-extensions "{{{pe-jvm-puppet-version}}}"]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.5.2"]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.7.2"]]
 
   :uberjar-name "jvm-puppet-release.jar"
 


### PR DESCRIPTION
This was using 0.5.2 which is pretty old, and also had an incompatible 
dependency on schema.
