### PR TITLE
(PE-5573) Update puppetserver and pe-jvm-puppet to j9-0.7.3

### DIFF
--- a/configs/pe-jvm-puppet/pe-jvm-puppet.clj
+++ b/configs/pe-jvm-puppet/pe-jvm-puppet.clj
@@ -2,7 +2,7 @@
   :description "Release artifacts for pe-jvm-puppet"
   :pedantic? :abort
   :dependencies [[puppetlabs/pe-jvm-puppet-extensions "{{{pe-jvm-puppet-version}}}"]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.7.2"]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.7.3"]]
 
   :uberjar-name "jvm-puppet-release.jar"
 

--- a/configs/puppetserver/puppetserver.clj
+++ b/configs/puppetserver/puppetserver.clj
@@ -2,7 +2,7 @@
   :description "Release artifacts for puppet-server"
   :pedantic? :abort
   :dependencies [[puppetlabs/puppet-server "{{{puppet-server-version}}}"]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.7.2"]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.7.3"]]
 
   :uberjar-name "puppet-server-release.jar"
 


### PR DESCRIPTION
tk-j9 v0.7.3 includes the ability to configure static assets to
be served up by Jetty.  This was a prerequisite for PE-5573.
This commit bumps both OSS and PE puppetserver packages
to the new jetty.
