### PR TITLE
(PE-5792) Create /var/log/$project during packaging

### DIFF
--- a/staging-templates/project_data.yaml.mustache
+++ b/staging-templates/project_data.yaml.mustache
@@ -28,9 +28,11 @@ templates:
   - ext/redhat/init.suse.erb
   - ext/debian/changelog.erb
   - ext/debian/control.erb
+  - ext/debian/dirs.erb
   - ext/debian/docs.erb
   - ext/debian/postrm.erb
   - ext/debian/preinst.erb
+  - ext/debian/postinst.erb
   - ext/debian/rules.erb
   - ext/bin/*.erb
   - ext/cli/apps/*.erb

--- a/template/foss/ext/debian/dirs.erb
+++ b/template/foss/ext/debian/dirs.erb
@@ -1,0 +1,1 @@
+var/log/<%= EZBake::Config[:project] %>

--- a/template/foss/ext/debian/postinst.erb
+++ b/template/foss/ext/debian/postinst.erb
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> /var/log/<%= EZBake::Config[:project] %>
+chmod 700 /var/log/<%= EZBake::Config[:project] %>

--- a/template/foss/ext/redhat/ezbake.spec.erb
+++ b/template/foss/ext/redhat/ezbake.spec.erb
@@ -103,6 +103,8 @@ install -m 0755 ext/default %{buildroot}%{_sysconfdir}/sysconfig/<%= EZBake::Con
 <%= install %>
 <% end -%>
 
+install -d -m 700 %{buildroot}%{_localstatedir}/log/<%= EZBake::Config[:project] %>
+
 <% unless EZBake::Config[:terminus_info].empty? -%>
 env DESTDIR=%{buildroot} rubylibdir=%{puppet_libdir} prefix=%{_prefix} make -e install-<%= EZBake::Config[:project] %>-termini
 <% end -%>
@@ -162,6 +164,7 @@ fi
 
 %files
 %defattr(-, root, root)
+%dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_localstatedir}/log/%{name}
 <% if File.exists?("ext/docs") %>
 %doc ext/docs
 <% end %>

--- a/template/pe/ext/debian/dirs.erb
+++ b/template/pe/ext/debian/dirs.erb
@@ -1,0 +1,1 @@
+var/log/<%= EZBake::Config[:project] %>

--- a/template/pe/ext/debian/postinst.erb
+++ b/template/pe/ext/debian/postinst.erb
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> /var/log/<%= EZBake::Config[:project] %>
+chmod 700 /var/log/<%= EZBake::Config[:project] %>

--- a/template/pe/ext/redhat/ezbake.spec.erb
+++ b/template/pe/ext/redhat/ezbake.spec.erb
@@ -158,6 +158,8 @@ install -m 0755 ext/default %{buildroot}%{_real_sysconfdir}/sysconfig/<%= EZBake
 <%= install %>
 <% end -%>
 
+install -d -m 700 %{buildroot}%{_localstatedir}/log/<%= EZBake::Config[:project] %>
+
 <% unless EZBake::Config[:terminus_info].empty? -%>
 env DESTDIR=%{buildroot} rubylibdir=%{puppet_libdir} prefix=%{_prefix} make -e install-<%= EZBake::Config[:project] %>-termini
 <% end -%>
@@ -229,6 +231,7 @@ fi
 
 %files
 %defattr(-, root, root)
+%dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_localstatedir}/log/%{name}
 <% if File.exists?("ext/docs") %>
 %doc ext/docs
 <% end %>


### PR DESCRIPTION
Previously the init script was used to create and ensure correct
permissions on the log dir during service start. This doesn't work for
el7, where systemd is in play. systemd has no facility to create a
logdir, and the user that the application will be running as will not be
able to make a directory in /var/log, so the packaging has to do it.
Once the directory has been created, logback will be able to create the
log file in the directory. This commit adds the logdir to the deb and
rpm packaging and ensures that the directory is 700 and owned by the
user and group for the ezbake project.
