### PR TITLE
(pe-5785) Fix quoting in sles init startproc call

### DIFF
--- a/template/pe/ext/redhat/init.suse.erb
+++ b/template/pe/ext/redhat/init.suse.erb
@@ -54,7 +54,7 @@ start() {
     [ -e "${config}" ] || exit 6
     install --owner "${USER}" --group "${USER}" --directory "/var/log/${prog}"
     echo -n $"Starting ${prog}: "
-    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" '-XX:OnOutOfMemoryError="kill -9 %p"' "${JAVA_ARGS}"
+    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" '-XX:OnOutOfMemoryError="kill -9 %p"' ${JAVA_ARGS}
     rc_status -v
     sleep 1
     find_my_pid


### PR DESCRIPTION
bash/startproc is passing JAVA_ARGS to java as a single argument,
instead of multiple arguments, when we have it quoted in the
startproc call in the sles init script. This removes that quoting.
