### PR TITLE
(PE-5792) Stop managing and creating logdir in init scripts

### DIFF
--- a/template/foss/ext/debian/ezbake.init.erb
+++ b/template/foss/ext/debian/ezbake.init.erb
@@ -48,9 +48,6 @@ EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" $JAVA_ARGS"
 #
 do_start()
 {
-    mkdir -p /var/log/<%= EZBake::Config[:project] %>
-    chown -R $USER /var/log/<%= EZBake::Config[:project] %>
-
     start-stop-daemon --start $EXTRA_ARGS --quiet --pidfile $PIDFILE --chdir $INSTALL_DIR --exec $JAVA_BIN \
         --startas /bin/bash -- -c "exec $EXEC >> /var/log/<%= EZBake::Config[:project] %>/<%= EZBake::Config[:project] %>-daemon.log 2>&1"
 }

--- a/template/foss/ext/redhat/init.erb
+++ b/template/foss/ext/redhat/init.erb
@@ -58,8 +58,6 @@ start() {
     rh_status_q
     [ -x $JAVA_BIN ] || exit 5
     [ -e $config ] || exit 6
-    mkdir -p /var/log/<%= EZBake::Config[:project] %>
-    chown -R $USER /var/log/<%= EZBake::Config[:project] %>
     # Move any heap dumps aside
     echo -n $"Starting $prog: "
     daemon --user $USER --pidfile $PIDFILE "$EXEC >> /var/log/<%= EZBake::Config[:project] %>/<%= EZBake::Config[:project] %>-daemon.log 2>&1 &"

--- a/template/pe/ext/debian/ezbake.init.erb
+++ b/template/pe/ext/debian/ezbake.init.erb
@@ -48,9 +48,6 @@ EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" $JAVA_ARGS"
 #
 do_start()
 {
-    mkdir -p /var/log/<%= EZBake::Config[:project] %>
-    chown -R $USER /var/log/<%= EZBake::Config[:project] %>
-
     start-stop-daemon --start $EXTRA_ARGS --quiet --pidfile $PIDFILE --chdir $INSTALL_DIR --exec $JAVA_BIN \
         --startas /bin/bash -- -c "exec $EXEC >> /var/log/<%= EZBake::Config[:project] %>/<%= EZBake::Config[:project] %>-daemon.log 2>&1"
 }

--- a/template/pe/ext/redhat/init.erb
+++ b/template/pe/ext/redhat/init.erb
@@ -58,8 +58,6 @@ start() {
     rh_status_q
     [ -x $JAVA_BIN ] || exit 5
     [ -e $config ] || exit 6
-    mkdir -p /var/log/<%= EZBake::Config[:project] %>
-    chown -R $USER /var/log/<%= EZBake::Config[:project] %>
     # Move any heap dumps aside
     echo -n $"Starting $prog: "
     daemon --user $USER --pidfile $PIDFILE "$EXEC >> /var/log/<%= EZBake::Config[:project] %>/<%= EZBake::Config[:project] %>-daemon.log 2>&1 &"

--- a/template/pe/ext/redhat/init.suse.erb
+++ b/template/pe/ext/redhat/init.suse.erb
@@ -52,7 +52,6 @@ find_my_pid() {
 start() {
     [ -x "${JAVA_BIN}" ] || exit 5
     [ -e "${config}" ] || exit 6
-    install --owner "${USER}" --group "${USER}" --directory "/var/log/${prog}"
     echo -n $"Starting ${prog}: "
     startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" '-XX:OnOutOfMemoryError="kill -9 %p"' ${JAVA_ARGS}
     rc_status -v


### PR DESCRIPTION
Now that we are installing the /var/log/$project directory during
packaging, there is no reason to do it in the init scripts. This commit
removes all of the making and chowning of the logdir from the init
script templates.
