### PR TITLE
(PE-5573) Bump tk-ws-j9 in pe-jvm-puppet to 0.7.4 for symlink support

### DIFF
--- a/configs/pe-jvm-puppet/pe-jvm-puppet.clj
+++ b/configs/pe-jvm-puppet/pe-jvm-puppet.clj
@@ -2,7 +2,7 @@
   :description "Release artifacts for pe-jvm-puppet"
   :pedantic? :abort
   :dependencies [[puppetlabs/pe-jvm-puppet-extensions "{{{pe-jvm-puppet-version}}}"]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.7.3"]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.7.4"]]
 
   :uberjar-name "jvm-puppet-release.jar"
 


### PR DESCRIPTION
This is necessary in order to follow symlinks when serving agent packages.
