### PR TITLE
(PE-5756) Add post-start action to ezbake

### DIFF
--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -372,9 +372,11 @@ Bundled packages: %s
          :debian-deps               (quoted-list (get-ezbake-value ezbake-vars upstream-ezbake-configs build-target :debian :dependencies))
          :debian-preinst            (quoted-list (get-ezbake-value ezbake-vars upstream-ezbake-configs build-target :debian :preinst))
          :debian-install            (quoted-list (get-ezbake-value ezbake-vars upstream-ezbake-configs build-target :debian :install))
+         :debian-post-start-action  (quoted-list (get-ezbake-value ezbake-vars upstream-ezbake-configs build-target :debian :post-start-action))
          :redhat-deps               (quoted-list (get-ezbake-value ezbake-vars upstream-ezbake-configs build-target :redhat :dependencies))
          :redhat-preinst            (quoted-list (get-ezbake-value ezbake-vars upstream-ezbake-configs build-target :redhat :preinst))
          :redhat-install            (quoted-list (get-ezbake-value ezbake-vars upstream-ezbake-configs build-target :redhat :install))
+         :redhat-post-start-action  (quoted-list (get-ezbake-value ezbake-vars upstream-ezbake-configs build-target :redhat :post-start-action))
          :terminus-map              termini
          :replaces-pkgs             (get-local-ezbake-var lein-project :replaces-pkgs [])
          :java-args                 (get-local-ezbake-var lein-project :java-args

--- a/staging-templates/ezbake.rb.mustache
+++ b/staging-templates/ezbake.rb.mustache
@@ -19,11 +19,13 @@ module EZBake
                     :additional_dependencies => [{{{debian-deps}}}],
                     :additional_preinst => [{{{debian-preinst}}}],
                     :additional_install => [{{{debian-install}}}],
+                    :post_start_action => [{{{debian-post-start-action}}}],
                  },
       :redhat => {
                     :additional_dependencies => [{{{redhat-deps}}}],
                     :additional_preinst => [{{{redhat-preinst}}}],
                     :additional_install => [{{{redhat-install}}}],
+                    :post_start_action => [{{{redhat-post-start-action}}}],
                  },
       :java_args => '{{{java-args}}}',
       :replaces_pkgs => {

--- a/template/foss/ext/debian/ezbake.init.erb
+++ b/template/foss/ext/debian/ezbake.init.erb
@@ -50,6 +50,17 @@ do_start()
 {
     start-stop-daemon --start $EXTRA_ARGS --quiet --pidfile $PIDFILE --chdir $INSTALL_DIR --exec $JAVA_BIN \
         --startas /bin/bash -- -c "exec $EXEC >> /var/log/<%= EZBake::Config[:project] %>/<%= EZBake::Config[:project] %>-daemon.log 2>&1"
+    retval=$?
+
+    <% if EZBake::Config[:debian][:post_start_action] -%>
+    if [ "$retval" -eq 0 ]; then
+    <% EZBake::Config[:debian][:post_start_action].each do |action| -%>
+        <%= action %>
+    <% end -%>
+    fi
+    <% end -%>
+
+    return $retval
 }
 
 #

--- a/template/foss/ext/redhat/ezbake.service.erb
+++ b/template/foss/ext/redhat/ezbake.service.erb
@@ -14,6 +14,10 @@ ExecStart=/usr/bin/java $JAVA_ARGS \
 
 ExecStop=/bin/kill $MAINPID
 
+<% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
+ExecStartPost=-<%= action %>
+<% end -%>
+
 StandardOutput=syslog
 
 [Install]

--- a/template/foss/ext/redhat/init.erb
+++ b/template/foss/ext/redhat/init.erb
@@ -55,12 +55,22 @@ start() {
     # Move any heap dumps aside
     echo -n $"Starting $prog: "
     daemon --user $USER --pidfile $PIDFILE "$EXEC >> /var/log/<%= EZBake::Config[:project] %>/<%= EZBake::Config[:project] %>-daemon.log 2>&1 &"
+    retval=$?
     sleep 1
     find_my_pid
     echo $pid > $PIDFILE
     [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"
     echo
     [ -s $PIDFILE ] && touch $lockfile
+
+    <% if EZBake::Config[:redhat][:post_start_action] -%>
+    if [ "$retval" -eq 0 ]; then
+    <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
+        <%= action %>
+    <% end -%>
+    fi
+    <% end -%>
+
     return $retval
 }
 

--- a/template/pe/ext/debian/ezbake.init.erb
+++ b/template/pe/ext/debian/ezbake.init.erb
@@ -50,6 +50,17 @@ do_start()
 {
     start-stop-daemon --start $EXTRA_ARGS --quiet --pidfile $PIDFILE --chdir $INSTALL_DIR --exec $JAVA_BIN \
         --startas /bin/bash -- -c "exec $EXEC >> /var/log/<%= EZBake::Config[:project] %>/<%= EZBake::Config[:project] %>-daemon.log 2>&1"
+    retval=$?
+
+    <% if EZBake::Config[:debian][:post_start_action] -%>
+    if [ "$retval" -eq 0 ]; then
+    <% EZBake::Config[:debian][:post_start_action].each do |action| -%>
+        <%= action %>
+    <% end -%>
+    fi
+    <% end -%>
+
+    return $retval
 }
 
 #

--- a/template/pe/ext/redhat/ezbake.service.erb
+++ b/template/pe/ext/redhat/ezbake.service.erb
@@ -14,6 +14,10 @@ ExecStart=/opt/puppet/bin/java $JAVA_ARGS \
 
 ExecStop=/bin/kill $MAINPID
 
+<% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
+ExecStartPost=-<%= action %>
+<% end -%>
+
 StandardOutput=syslog
 
 [Install]

--- a/template/pe/ext/redhat/init.erb
+++ b/template/pe/ext/redhat/init.erb
@@ -55,12 +55,22 @@ start() {
     # Move any heap dumps aside
     echo -n $"Starting $prog: "
     daemon --user $USER --pidfile $PIDFILE "$EXEC >> /var/log/<%= EZBake::Config[:project] %>/<%= EZBake::Config[:project] %>-daemon.log 2>&1 &"
+    retval=$?
     sleep 1
     find_my_pid
     echo $pid > $PIDFILE
     [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"
     echo
     [ -s $PIDFILE ] && touch $lockfile
+
+    <% if EZBake::Config[:redhat][:post_start_action] -%>
+    if [ "$retval" -eq 0 ]; then
+    <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
+        <%= action %>
+    <% end -%>
+    fi
+    <% end -%>
+
     return $retval
 }
 

--- a/template/pe/ext/redhat/init.suse.erb
+++ b/template/pe/ext/redhat/init.suse.erb
@@ -55,6 +55,16 @@ start() {
     echo -n $"Starting ${prog}: "
     startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" '-XX:OnOutOfMemoryError="kill -9 %p"' ${JAVA_ARGS}
     rc_status -v
+
+    <% if EZBake::Config[:redhat][:post_start_action] -%>
+    if [ "$?" -eq 0]; then
+    <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
+        <%= action %>
+    <% end -%>
+    fi
+    <% end -%>
+
+    fi
     sleep 1
     find_my_pid
     echo "${pid}" > "${PIDFILE}"


### PR DESCRIPTION
This adds the post-start-action to the ezbake.rb so that it will be
available to be used with packaging. This commit also includes changes
to the foss and PE packaging to use the post-start-action if it is
specified. It is implemented so that it only is invoked if the start was
successful and it does not impact the exit status of the service start
call.
