### PR TITLE
(MAINT) Fix init script bug when no post_start_action specified.

### DIFF
--- a/template/foss/ext/debian/ezbake.init.erb
+++ b/template/foss/ext/debian/ezbake.init.erb
@@ -52,7 +52,7 @@ do_start()
         --startas /bin/bash -- -c "exec $EXEC >> /var/log/<%= EZBake::Config[:project] %>/<%= EZBake::Config[:project] %>-daemon.log 2>&1"
     retval=$?
 
-    <% if EZBake::Config[:debian][:post_start_action] -%>
+    <% if not EZBake::Config[:debian][:post_start_action].empty? -%>
     if [ "$retval" -eq 0 ]; then
     <% EZBake::Config[:debian][:post_start_action].each do |action| -%>
         <%= action %>

--- a/template/foss/ext/redhat/init.erb
+++ b/template/foss/ext/redhat/init.erb
@@ -63,7 +63,7 @@ start() {
     echo
     [ -s $PIDFILE ] && touch $lockfile
 
-    <% if EZBake::Config[:redhat][:post_start_action] -%>
+    <% if not EZBake::Config[:redhat][:post_start_action].empty? -%>
     if [ "$retval" -eq 0 ]; then
     <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
         <%= action %>

--- a/template/pe/ext/debian/ezbake.init.erb
+++ b/template/pe/ext/debian/ezbake.init.erb
@@ -52,7 +52,7 @@ do_start()
         --startas /bin/bash -- -c "exec $EXEC >> /var/log/<%= EZBake::Config[:project] %>/<%= EZBake::Config[:project] %>-daemon.log 2>&1"
     retval=$?
 
-    <% if EZBake::Config[:debian][:post_start_action] -%>
+    <% if not EZBake::Config[:debian][:post_start_action].empty? -%>
     if [ "$retval" -eq 0 ]; then
     <% EZBake::Config[:debian][:post_start_action].each do |action| -%>
         <%= action %>

--- a/template/pe/ext/redhat/init.erb
+++ b/template/pe/ext/redhat/init.erb
@@ -63,7 +63,7 @@ start() {
     echo
     [ -s $PIDFILE ] && touch $lockfile
 
-    <% if EZBake::Config[:redhat][:post_start_action] -%>
+    <% if not EZBake::Config[:redhat][:post_start_action].empty? -%>
     if [ "$retval" -eq 0 ]; then
     <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
         <%= action %>

--- a/template/pe/ext/redhat/init.suse.erb
+++ b/template/pe/ext/redhat/init.suse.erb
@@ -56,7 +56,7 @@ start() {
     startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" '-XX:OnOutOfMemoryError="kill -9 %p"' ${JAVA_ARGS}
     rc_status -v
 
-    <% if EZBake::Config[:redhat][:post_start_action] -%>
+    <% if not EZBake::Config[:redhat][:post_start_action].empty? -%>
     if [ "$?" -eq 0]; then
     <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
         <%= action %>


### PR DESCRIPTION
By default the post_start_action is an empty list which is a logical 'true'
value in Ruby. The previous logic led to an empty `if` block in the init scripts
which is a syntax error in sh and probably other shell script interpreters.

Signed-off-by: Wayne wayne@puppetlabs.com
