### PR TITLE
Add pe-rbac-service to classifier's dependencies.

### DIFF
--- a/configs/classifier/classifier.clj
+++ b/configs/classifier/classifier.clj
@@ -2,6 +2,7 @@
   :description "Release artifacts for classifier"
   :pedantic? :abort
   :dependencies [[puppetlabs/classifier "{{{classifier-version}}}"]
+                 [puppetlabs/pe-rbac-service "{{{pe-rbac-version}}}"]
                  [puppetlabs/trapperkeeper-webserver-jetty9 "0.7.2"]]
 
   :uberjar-name "classifier-release.jar"


### PR DESCRIPTION
As of NC-213, the classifier now depends on pe-rbac service, so add it to the dependencies in classifier.clj.
