### PR TITLE
(maint) Export HOME in Suse init script

### DIFF
--- a/template/pe/ext/redhat/init.suse.erb
+++ b/template/pe/ext/redhat/init.suse.erb
@@ -53,6 +53,7 @@ start() {
     [ -x "${JAVA_BIN}" ] || exit 5
     [ -e "${config}" ] || exit 6
     echo -n $"Starting ${prog}: "
+    export HOME="$(getent passwd ${USER} | cut -d':' -f6)"
     startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" '-XX:OnOutOfMemoryError="kill -9 %p"' ${JAVA_ARGS}
     rc_status -v
 


### PR DESCRIPTION
Suse exposes an absolutely minimal set of environment variables to
daemons, but at least one of ours (Puppet) assumes that HOME is set to
a sane value. To make things less insane on SuSE, we just augment the
environment before starting services.
