### PR TITLE
(maint) Remove OnOutOfMemoryError from systemd service files

### DIFF
--- a/template/foss/ext/redhat/ezbake.service.erb
+++ b/template/foss/ext/redhat/ezbake.service.erb
@@ -8,7 +8,6 @@ EnvironmentFile=/etc/sysconfig/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 
 ExecStart=/usr/bin/java $JAVA_ARGS \
-          -XX:OnOutOfMemoryError=\"kill -9 %p\" \
           -XX:+HeapDumpOnOutOfMemoryError \
           -XX:HeapDumpPath=/var/log/$NAME.hprof \
           -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" clojure.main \

--- a/template/pe/ext/redhat/ezbake.service.erb
+++ b/template/pe/ext/redhat/ezbake.service.erb
@@ -8,7 +8,6 @@ EnvironmentFile=/etc/sysconfig/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 
 ExecStart=/opt/puppet/bin/java $JAVA_ARGS \
-          -XX:OnOutOfMemoryError=\"kill -9 %p\" \
           -XX:+HeapDumpOnOutOfMemoryError \
           -XX:HeapDumpPath=/var/log/$NAME.hprof \
           -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" clojure.main \


### PR DESCRIPTION
The kill in the OnOutOfMemoryError setting in the systemd service files
causes systemd to try to run the command for some reason. Possibly
something to do with escaping quotes. Until this can be fixed, this
commit removes those settings from the systemd service definitions.
