### PR TITLE
(SERVER-3) Update EL and sles init scripts to invoke the daemon from INSTALL_DIR

### DIFF
--- a/template/foss/ext/redhat/init.erb
+++ b/template/foss/ext/redhat/init.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Puppet Labs <%= EZBake::Config[:project] %>
 #
@@ -54,9 +54,11 @@ start() {
     [ -e $config ] || exit 6
     # Move any heap dumps aside
     echo -n $"Starting $prog: "
+    pushd "${INSTALL_DIR}" &> /dev/null
     daemon --user $USER --pidfile $PIDFILE "$EXEC >> /var/log/<%= EZBake::Config[:project] %>/<%= EZBake::Config[:project] %>-daemon.log 2>&1 &"
     retval=$?
     sleep 1
+    popd &> /dev/null
     find_my_pid
     echo $pid > $PIDFILE
     [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"

--- a/template/pe/ext/redhat/init.erb
+++ b/template/pe/ext/redhat/init.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Puppet Labs <%= EZBake::Config[:project] %>
 #
@@ -54,9 +54,11 @@ start() {
     [ -e $config ] || exit 6
     # Move any heap dumps aside
     echo -n $"Starting $prog: "
+    pushd "${INSTALL_DIR}" &> /dev/null
     daemon --user $USER --pidfile $PIDFILE "$EXEC >> /var/log/<%= EZBake::Config[:project] %>/<%= EZBake::Config[:project] %>-daemon.log 2>&1 &"
     retval=$?
     sleep 1
+    popd &> /dev/null
     find_my_pid
     echo $pid > $PIDFILE
     [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"

--- a/template/pe/ext/redhat/init.suse.erb
+++ b/template/pe/ext/redhat/init.suse.erb
@@ -54,7 +54,7 @@ start() {
     [ -e "${config}" ] || exit 6
     echo -n $"Starting ${prog}: "
     export HOME="$(getent passwd ${USER} | cut -d':' -f6)"
-    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" '-XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}' ${JAVA_ARGS}
+    startproc -u "${USER}" -l "${LOGFILE}" -c "${INSTALL_DIR}" -p "${PIDFILE}" -- "${JAVA_BIN}" '-XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}' ${JAVA_ARGS}
     rc_status -v
 
     <% if not EZBake::Config[:redhat][:post_start_action].empty? -%>
@@ -81,7 +81,7 @@ stop() {
         echo "${pid}" > "${PIDFILE}"
     fi
 
-    killproc -p "${PIDFILE}" -t"${SERVICE_STOP_RETRIES}"s -- "${JAVA_BIN}" '-XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}' "${JAVA_ARGS}"
+    killproc -p "${PIDFILE}" -c "${INSTALL_DIR}" -t"${SERVICE_STOP_RETRIES}"s -- "${JAVA_BIN}" '-XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}' "${JAVA_ARGS}"
     rc_status -v
     retval=$?
     [ $retval -eq 0 ] && log_success_msg $"${prog} stopped" || log_failure_msg $"${prog} stopped"
@@ -99,7 +99,7 @@ sl_status_q() {
 }
 
 sl_status() {
-    checkproc -p "${PIDFILE}" -- "${JAVA_BIN}" '-XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}' "${JAVA_ARGS}"
+    checkproc -p "${PIDFILE}" -c "${INSTALL_DIR}" -- "${JAVA_BIN}" '-XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}' "${JAVA_ARGS}"
     rc_status -v
 }
 


### PR DESCRIPTION
On el systems, if the service is invoked using init.d directly, while in
a root owned directory, it will fail to run several external commands
during startup. This isn't a problem for debian because we pass in a
directory to run from that will be accessible to the service user. This
commit implements the same behavior for EL and sles. On el this is
accomplished by using pushd (which means the shell invoking the init
script must be bash) to move into the $INSTALL_DIR directory, which
defaults to the home directory of the service user. On sles, the -c
option is passed to startproc (which means it must also be passed to
checkproc and killproc), which will ensure the daemon is started from
the $INSTALL_DIR directory.
