### PR TITLE
(maint) Update uberjar-name for pe-puppetserver

### DIFF
--- a/configs/pe-puppetserver/pe-puppetserver.clj
+++ b/configs/pe-puppetserver/pe-puppetserver.clj
@@ -4,7 +4,7 @@
   :dependencies [[puppetlabs/pe-puppet-server-extensions "{{{pe-puppet-server-version}}}"]
                  [puppetlabs/trapperkeeper-webserver-jetty9 "0.7.4"]]
 
-  :uberjar-name "jvm-puppet-release.jar"
+  :uberjar-name "puppet-server-release.jar"
 
   :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]
                  ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]


### PR DESCRIPTION
In the rename from jvm-puppet to puppetserver, the uberjar was
neglected. This commit updates the uberjar-name to
puppet-server-release, which matches the name of the puppet-server
uberjar.
