### PR TITLE
(maint) Use pushd/popd instead of -c for sles init scripts

### DIFF
--- a/template/pe/ext/redhat/init.suse.erb
+++ b/template/pe/ext/redhat/init.suse.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Puppet Labs <%= EZBake::Config[:project] %>
 #
@@ -54,7 +54,8 @@ start() {
     [ -e "${config}" ] || exit 6
     echo -n $"Starting ${prog}: "
     export HOME="$(getent passwd ${USER} | cut -d':' -f6)"
-    startproc -u "${USER}" -l "${LOGFILE}" -c "${INSTALL_DIR}" -p "${PIDFILE}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}" ${JAVA_ARGS}
+    pushd ${INSTALL_DIR} &> /dev/null
+    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}" ${JAVA_ARGS}
     rc_status -v
 
     <% if not EZBake::Config[:redhat][:post_start_action].empty? -%>
@@ -66,6 +67,7 @@ start() {
     <% end -%>
 
     sleep 1
+    popd &> /dev/null
     find_my_pid
     echo "${pid}" > "${PIDFILE}"
     [ -s "${PIDFILE}" ] && log_success_msg $"${prog} startup" || log_failure_msg $"${prog} startup"
@@ -81,7 +83,7 @@ stop() {
         echo "${pid}" > "${PIDFILE}"
     fi
 
-    killproc -p "${PIDFILE}" -c "${INSTALL_DIR}" -t"${SERVICE_STOP_RETRIES}"s -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}" "${JAVA_ARGS}"
+    killproc -p "${PIDFILE}" -t"${SERVICE_STOP_RETRIES}"s -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}" "${JAVA_ARGS}"
     rc_status -v
     retval=$?
     [ $retval -eq 0 ] && log_success_msg $"${prog} stopped" || log_failure_msg $"${prog} stopped"
@@ -99,7 +101,7 @@ sl_status_q() {
 }
 
 sl_status() {
-    checkproc -p "${PIDFILE}" -c "${INSTALL_DIR}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}" "${JAVA_ARGS}"
+    checkproc -p "${PIDFILE}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}" "${JAVA_ARGS}"
     rc_status -v
 }
 


### PR DESCRIPTION
-c did not behave as expected. Sles used the directory specified as a
chroot and then tried to find the daemon (/opt/puppet/bin/java) within
the directory, where it wouldn't exist. This commit updates the proc
calls to remove the -c, and replaces the one in the start function with
a pushd/popd. The use of pushd means that the shell has to be bash, so
that is also updated.
