### PR TITLE
(SERVER-8) Remove ExecStop, add KillMode to systemd services

### DIFF
--- a/template/foss/ext/redhat/ezbake.service.erb
+++ b/template/foss/ext/redhat/ezbake.service.erb
@@ -15,7 +15,7 @@ ExecStart=/usr/bin/java $JAVA_ARGS \
           -m puppetlabs.trapperkeeper.main --config "${CONFIG}" \
           -b "${BOOTSTRAP_CONFIG}" $@
 
-ExecStop=/bin/kill $MAINPID
+KillMode=process
 
 <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
 ExecStartPost=-<%= action %>

--- a/template/pe/ext/redhat/ezbake.service.erb
+++ b/template/pe/ext/redhat/ezbake.service.erb
@@ -15,7 +15,7 @@ ExecStart=/opt/puppet/bin/java $JAVA_ARGS \
           -m puppetlabs.trapperkeeper.main --config "${CONFIG}" \
           -b "${BOOTSTRAP_CONFIG}" $@
 
-ExecStop=/bin/kill $MAINPID
+KillMode=process
 
 <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
 ExecStartPost=-<%= action %>


### PR DESCRIPTION
The currently specified ExecStop is already the default behavior in
systemd, so it is not required. It also causes issues if the service
hasn't started and there is no MAINPID defined. This commit removes that
setting and adds KillMode instead. KillMode=process, as described in
http://www.freedesktop.org/software/systemd/man/systemd.kill.html, will
only target the main process, which should be all that exists in our
clojure applications.
