### PR TITLE
(PE-4981) Remove 'hostname' setting from global config

### DIFF
--- a/configs/pe-puppetserver/config/conf.d/global.conf
+++ b/configs/pe-puppetserver/config/conf.d/global.conf
@@ -2,5 +2,4 @@ global: {
   # TODO: this is the paths on default el6 OSS install;
   # this can't be hard-coded like this in the long run
   logging-config: /etc/puppetlabs/pe-puppetserver/logback.xml
-  hostname: localhost
 }


### PR DESCRIPTION
Prior to this commit we had a 'hostname' setting in the 'global'
section of the config.  This was only being used as an id when
creating namespaces for metrics.  I didn't feel like it made
sense there, since it's possible users would want to use a different
id for metrics besides the actual hostname, and there are already
other settings that capture the hostname.  In a related PR against
pe-puppet-server, the setting is moved out of the `global` section;
this commit removes it from the ezbake config as well.
