### PR TITLE
Move product config to global.conf

### DIFF
--- a/configs/puppetserver/config/conf.d/global.conf
+++ b/configs/puppetserver/config/conf.d/global.conf
@@ -3,3 +3,7 @@ global: {
     # info, see http://logback.qos.ch/manual/configuration.html
     logging-config: /etc/puppetserver/logback.xml
 }
+
+product: {
+    name: puppetserver
+}


### PR DESCRIPTION
Prior to this commit, the product config (which is used when
reporting the product name to dujour) was in the `puppetserver.conf`
file.  This commit moves it to the `global.conf` file, where it
will be less visible to the end user.
