### PR TITLE
Update RPM metadata to use public URL

### DIFF
--- a/template/foss/ext/redhat/ezbake.spec.erb
+++ b/template/foss/ext/redhat/ezbake.spec.erb
@@ -31,7 +31,7 @@ BuildRoot:        %{_tmppath}/%{realname}-%{version}-%{release}-root-%(%{__id_u}
 Summary:          Puppet Labs - <%= EZBake::Config[:project] %>
 License:          ASL 2.0
 
-URL:              http://github.com/puppetlabs/ezbake
+URL:              http://puppetlabs.com
 Source0:          %{name}-%{realversion}.tar.gz
 
 Group:            System Environment/Daemons


### PR DESCRIPTION
This patch changes the URL used by the EZBake template for RPM spec files from `http://github.com/puppetlabs/ezbake`, which is not publicly accessible, to `http://puppetlabs.com`, which matches the Homepage used by the template for Debian control files.
