### PR TITLE
Update PE RPM metadata to use public URL

### DIFF
--- a/template/pe/ext/redhat/ezbake.spec.erb
+++ b/template/pe/ext/redhat/ezbake.spec.erb
@@ -70,7 +70,7 @@ BuildRoot:        %{_tmppath}/%{realname}-%{version}-%{release}-root-%(%{__id_u}
 Summary:          Puppet Labs - <%= EZBake::Config[:project] %>
 License:          PL Commercial
 
-URL:              http://github.com/puppetlabs/ezbake
+URL:              http://puppetlabs.com
 Source0:          %{name}-%{realversion}.tar.gz
 
 Group:            System Environment/Daemons


### PR DESCRIPTION
This patch changes the URL used by the EZBake template for PE RPM spec files
from `http://github.com/puppetlabs/ezbake`, which is not publicly accessible,
to `http://puppetlabs.com`, which matches the Homepage used by the template for
Debian control files.
