### PR TITLE
Update PE and FOSS puppetserver boostrap files

### DIFF
--- a/configs/pe-puppetserver/config/bootstrap.cfg
+++ b/configs/pe-puppetserver/config/bootstrap.cfg
@@ -5,4 +5,11 @@ puppetlabs.enterprise.services.puppet-profiler.puppet-profiler-service/metrics-p
 puppetlabs.enterprise.services.metrics.metrics-service/metrics-service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
 puppetlabs.services.config.puppet-server-config-service/puppet-server-config-service
+
+# To enable the CA service, leave the following line uncommented
 puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
+# To disable the CA service, comment out the above line and uncomment the line below
+#puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
+# To enable the reverse-proxy CA service, comment out the above two lines and uncomment the line below
+#puppetlabs.enterprise.services.reverse-proxy.reverse-proxy-ca-service/reverse-proxy-ca-service
+

--- a/configs/puppetserver/config/bootstrap.cfg
+++ b/configs/puppetserver/config/bootstrap.cfg
@@ -3,6 +3,11 @@ puppetlabs.services.jruby.jruby-puppet-service/jruby-puppet-pooled-service
 puppetlabs.services.puppet-profiler.puppet-profiler-service/puppet-profiler-service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
 puppetlabs.services.config.puppet-server-config-service/puppet-server-config-service
-puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
 puppetlabs.services.master.master-service/master-service
 puppetlabs.services.version.version-check-service/version-check-service
+
+# To enable the CA service, leave the following line uncommented
+puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
+# To disable the CA service, comment out the above line and uncomment the line below
+#puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
+


### PR DESCRIPTION
Update the PE and FOSS puppetserver boostrap files to reflect
the new options for the CA service.

I didn't do ezbake builds of these two projects to test these bootstrap.cfg files, but I did copy them into my local copies of the puppet-server and pe-puppet-server-extensions repo to verify that they work.
