### PR TITLE
(PE-6449) Change bindir for PE on debian

### DIFF
--- a/template/pe/ext/debian/rules.erb
+++ b/template/pe/ext/debian/rules.erb
@@ -7,6 +7,7 @@ rubylibdir=$(shell /opt/puppet/bin/ruby -rrbconfig -e "puts RbConfig::CONFIG['si
 
 export DESTDIR=$(BUILD_ROOT)
 export prefix=/opt/puppet
+export bindir=/opt/puppet/bin
 export rubylibdir
 export confdir=/etc/puppetlabs
 export realname=<%= EZBake::Config[:real_name] %>


### PR DESCRIPTION
Change the bindir for PE on debian to be /opt/puppet/bin instead
of /usr/bin.
