### PR TITLE
(EZ-1) Update sysconfig name file to not be replaced on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ lein run build
 ```
 
 If you are attempting to create a development build for local testing, and do
-not intend on actually releasing an artifact, please see [Developing ezbake][]
-before running these commands.
+not intend on actually releasing an artifact, please see [Developing ezbake]
+(#developing-ezbake) before running these commands.
 
 TODO: `stage` command needs to support some CLI args, to allow you to specify
 FOSS vs PE and select which project to build.

--- a/template/foss/ext/redhat/ezbake.spec.erb
+++ b/template/foss/ext/redhat/ezbake.spec.erb
@@ -175,7 +175,7 @@ fi
 %{_initrddir}/%{name}
 %endif
 %config(noreplace) %{_sysconfdir}/%{name}
-%{_sysconfdir}/sysconfig/%{name}
+%config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 <% if ! EZBake::Config[:cli_app_files].empty? -%>
 %{_bindir}/<%= EZBake::Config[:real_name] %>
 <% end -%>

--- a/template/pe/ext/redhat/ezbake.spec.erb
+++ b/template/pe/ext/redhat/ezbake.spec.erb
@@ -242,7 +242,7 @@ fi
 %{_initrddir}/%{name}
 %endif
 %config(noreplace) %{_sysconfdir}/%{realname}
-%{_real_sysconfdir}/sysconfig/%{name}
+%config(noreplace) %{_real_sysconfdir}/sysconfig/%{name}
 <% if ! EZBake::Config[:cli_app_files].empty? -%>
 %{_bindir}/<%= EZBake::Config[:real_name] %>
 <% end -%>


### PR DESCRIPTION
This commit adds a `%config(noreplace)` directive to the sysconfig name
file in the RedHat spec erb files.  This allows an upgrade package being
installed to not replace any customizations that a user might have done
to the name file after a previous install.

This commit also has one other minor update to the link to the
"Developing ezbake" section in the `README.md`.
