### PR TITLE
(SERVER-70) Update systemd template for nonzero exit codes

### DIFF
--- a/template/foss/ext/redhat/ezbake.service.erb
+++ b/template/foss/ext/redhat/ezbake.service.erb
@@ -21,6 +21,7 @@ KillMode=process
 <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
 ExecStartPost=-<%= action %>
 <% end -%>
+SuccessExitStatus=143
 
 StandardOutput=syslog
 

--- a/template/pe/ext/redhat/ezbake.service.erb
+++ b/template/pe/ext/redhat/ezbake.service.erb
@@ -21,6 +21,7 @@ KillMode=process
 <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
 ExecStartPost=-<%= action %>
 <% end -%>
+SuccessExitStatus=143
 
 StandardOutput=syslog
 


### PR DESCRIPTION
Because of the way that java handles the TERM signal (which is what
systemd uses by default), systemd considers the stoppage to have failed
and puts the service in a failed state. This is because our clojure
libraries don't catch or handle the TERM signal, but we can work around
it in the service file for the time being. This commit adds 143 to the
list of successful exit statuses for ezbake services. That is what java
returns when it gets a TERM signal.
