### PR TITLE
(SERVER-98) Fix systemd failure

### DIFF
--- a/template/foss/ext/redhat/ezbake.service.erb
+++ b/template/foss/ext/redhat/ezbake.service.erb
@@ -6,7 +6,7 @@ After=syslog.target network.target
 Type=simple
 EnvironmentFile=/etc/sysconfig/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
-TimeoutStopSec=${SERVICE_STOP_RETRIES}
+TimeoutStopSec=60
 
 ExecStart=/usr/bin/java $JAVA_ARGS \
           -XX:OnOutOfMemoryError=kill\ -9\ %p \

--- a/template/pe/ext/redhat/ezbake.service.erb
+++ b/template/pe/ext/redhat/ezbake.service.erb
@@ -6,7 +6,7 @@ After=syslog.target network.target
 Type=simple
 EnvironmentFile=/etc/sysconfig/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
-TimeoutStopSec=${SERVICE_STOP_RETRIES}
+TimeoutStopSec=60
 
 ExecStart=/opt/puppet/bin/java $JAVA_ARGS \
           -XX:OnOutOfMemoryError=kill\ -9\ %p \


### PR DESCRIPTION
Fix systemd failure that was occurring due to systemd not being
able to parse the TimeoutStopSec variable.
