### PR TITLE
(SERVER-29) exclude BouncyCastle jars from uberjar

### DIFF
--- a/configs/pe-puppetserver/pe-puppetserver.clj
+++ b/configs/pe-puppetserver/pe-puppetserver.clj
@@ -6,6 +6,11 @@
 
   :uberjar-name "puppet-server-release.jar"
 
+  ;; JRuby bundles the (un-exploded) BouncyCastle .jars.
+  ;; We don't want them in our uberjar,
+  ;; since we define our own dependency on BouncyCastle.
+  :uberjar-exclusions [#"META-INF/jruby.home/lib/ruby/shared/org/bouncycastle"]
+
   :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]
                  ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
   :main puppetlabs.trapperkeeper.main

--- a/configs/puppetserver/puppetserver.clj
+++ b/configs/puppetserver/puppetserver.clj
@@ -6,6 +6,11 @@
 
   :uberjar-name "puppet-server-release.jar"
 
+  ;; JRuby bundles the (un-exploded) BouncyCastle .jars.
+  ;; We don't want them in our uberjar,
+  ;; since we define our own dependency on BouncyCastle.
+  :uberjar-exclusions [#"META-INF/jruby.home/lib/ruby/shared/org/bouncycastle"]
+
   :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]
                  ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
   :main puppetlabs.trapperkeeper.main


### PR DESCRIPTION
Yo dawg, JRuby bundles the BouncyCastle .jars in its .jar.  Avoid using
these, since this project defines its own dependency on BouncyCastle directly.

@cprice404 here ya go, as requested.
