### PR TITLE
(PDB-663) Changes to make PuppetDB work with ezbake

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ can be configured here include the following:
   started
 * `:replaces-pkgs`: A list of maps of packages and versions that this ezbake
   package will replace
+* `:main-namespace`: The namespace where clojure will execute the -main
+  function to begin the application.
+* `:create-varlib`: Create a suitable `/var/lib/[project]` directory.
 
 Here is an example ezbake section:
 

--- a/configs/puppetdb/puppetdb.clj
+++ b/configs/puppetdb/puppetdb.clj
@@ -1,0 +1,19 @@
+(defproject puppetlabs.packages/puppetdb "{{{puppetdb-version}}}"
+  :description "Release artifacts for PuppetDB"
+  :pedantic? :abort
+  :dependencies [[puppetlabs/puppetdb "{{{puppetdb-version}}}"]
+                 ;; This is intended to work around what we believe is a
+                 ;; leiningen bug. Otherwise tools.nrepl gets stripped out by
+                 ;; leiningen: https://github.com/technomancy/leiningen/issues/1762
+                 [org.clojure/tools.nrepl "0.2.3"]]
+
+  :uberjar-name "puppetdb-release.jar"
+
+  :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]
+                 ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
+
+  :ezbake {:user "puppetdb"
+           :group "puppetdb"
+           :build-type "foss"
+           :main-namespace "puppetlabs.puppetdb.main"
+           :create-varlib true})

--- a/staging-templates/cli-app.erb
+++ b/staging-templates/cli-app.erb
@@ -3,8 +3,14 @@
 set -a
 if [ -r "/etc/default/<%= EZBake::Config[:project] -%>" ] ; then
     . /etc/default/<%= EZBake::Config[:project] %>
-elif [ -r  "/etc/sysconfig/<%= EZBake::Config[:project] -%>" ] ; then
+elif [ -r "/etc/sysconfig/<%= EZBake::Config[:project] -%>" ] ; then
     . /etc/sysconfig/<%= EZBake::Config[:project] %>
+elif [ `uname` == "OpenBSD" ] ; then
+    JAVA_BIN=$(javaPathHelper -c <%= EZBake::Config[:project] %>)
+    JAVA_ARGS="<%= EZBake::Config[:java_args] %>"
+    USER="_<%= EZBake::Config[:user] %>"
+    INSTALL_DIR="/usr/local/share/<%= EZBake::Config[:project] %>"
+    CONFIG="/etc/<%= EZBake::Config[:project] %>/conf.d"
 else
     echo "You seem to be missing some important configuration files; could not find /etc/default/<%= EZBake::Config[:project] -%> or /etc/sysconfig/<%= EZBake::Config[:project] -%>" >&2
     exit 1
@@ -28,7 +34,7 @@ function usage {
     fi
 
     cat <<EOD
-usage: $(basename $0) [--help] <command> [<args>]
+usage: $(basename $0) ([--help] | [--version]) <command> [<args>]
 
 The most commonly used <%= EZBake::Config[:real_name] %> commands are:
 EOD
@@ -41,6 +47,13 @@ EOD
     cat << EOD
 
 See '$(basename $0) <command> -h' for more information on a specific command.
+EOD
+    exit 0
+}
+
+function show_version {
+    cat <<EOD
+<%= EZBake::Config[:real_name] %> version: <%= Pkg::Config.version %>
 EOD
     exit 0
 }
@@ -72,6 +85,9 @@ function execsubcommand {
 
 if [ -z $1 ] || [ $1 = "--help" ] || [ $1 = "-h" ]; then
     usage
+fi
+if [ $1 = "--version" ] || [ $1 = "-v" ]; then
+    show_version
 fi
 
 execsubcommand "$@"

--- a/staging-templates/ezbake.rb.mustache
+++ b/staging-templates/ezbake.rb.mustache
@@ -9,6 +9,7 @@ module EZBake
       :config_files   => [{{{config-files}}}],
       :cli_app_files  => [{{{cli-app-files}}}],
       :bin_files      => [{{{bin-files}}}],
+      :create_varlib  => {{create-varlib}},
       :terminus_info  => {
                           {{#terminus-map}}
                             "{{{name}}}" => {
@@ -20,15 +21,18 @@ module EZBake
       :debian         => {
                           :additional_dependencies => [{{{debian-deps}}}],
                           :additional_preinst => [{{{debian-preinst}}}],
+                          :additional_postinst => [{{{debian-postinst}}}],
                           :additional_install => [{{{debian-install}}}],
                           :post_start_action => [{{{debian-post-start-action}}}],
                           },
       :redhat         => {
                           :additional_dependencies => [{{{redhat-deps}}}],
                           :additional_preinst => [{{{redhat-preinst}}}],
+                          :additional_postinst => [{{{redhat-postinst}}}],
                           :additional_install => [{{{redhat-install}}}],
                           :post_start_action => [{{{redhat-post-start-action}}}],
                           },
+      :main_namespace => '{{{main-namespace}}}',
       :java_args      => '{{{java-args}}}',
       :replaces_pkgs  => {
                           {{#replaces-pkgs}}

--- a/staging-templates/project_data.yaml.mustache
+++ b/staging-templates/project_data.yaml.mustache
@@ -38,6 +38,7 @@ templates:
   - ext/debian/preinst.erb
   - ext/debian/postinst.erb
   - ext/debian/rules.erb
+  - ext/config/conf.d/*.erb
   - ext/bin/*.erb
   - ext/cli/apps/*.erb
   - ext/cli/*.erb

--- a/template/foss/ext/debian/dirs.erb
+++ b/template/foss/ext/debian/dirs.erb
@@ -1,1 +1,4 @@
 var/log/<%= EZBake::Config[:project] %>
+<% if EZBake::Config[:create_varlib] -%>
+var/lib/<%= EZBake::Config[:project] %>
+<% end -%>

--- a/template/foss/ext/debian/ezbake.init.erb
+++ b/template/foss/ext/debian/ezbake.init.erb
@@ -31,9 +31,9 @@ PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 START_TIMEOUT=${START_TIMEOUT:-60}
 
-JAVA_ARGS="${JAVA_ARGS} -jar ${INSTALL_DIR}/${JARFILE} --config ${CONFIG} --bootstrap-config ${BOOTSTRAP_CONFIG}"
+JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b '${BOOTSTRAP_CONFIG}'"
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
-EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/$NAME $JAVA_ARGS"
+EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/$NAME -Djava.security.egd=/dev/urandom $JAVA_ARGS"
 
 # Exit if the package is not installed
 [ -x "$JAVA_BIN" ] || exit 0

--- a/template/foss/ext/debian/postinst.erb
+++ b/template/foss/ext/debian/postinst.erb
@@ -2,3 +2,11 @@
 
 chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> /var/log/<%= EZBake::Config[:project] %>
 chmod 700 /var/log/<%= EZBake::Config[:project] %>
+<% if EZBake::Config[:create_varlib] -%>
+chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> /var/lib/<%= EZBake::Config[:project] %>
+chmod 700 /var/lib/<%= EZBake::Config[:project] %>
+<% end -%>
+
+<% EZBake::Config[:debian][:additional_postinst].each do |cmd| -%>
+<%= cmd %>
+<% end -%>

--- a/template/foss/ext/debian/rules.erb
+++ b/template/foss/ext/debian/rules.erb
@@ -12,6 +12,9 @@ export prefix=/usr
 export bindir=/usr/bin
 export rubylibdir
 export confdir=/etc
+export datadir=$(prefix)/share
+export sharedstatedir=/var/lib
+
 export realname=<%= EZBake::Config[:real_name] %>
 
 install/<%= EZBake::Config[:project] %>::

--- a/template/foss/ext/redhat/ezbake.service.erb
+++ b/template/foss/ext/redhat/ezbake.service.erb
@@ -12,8 +12,10 @@ ExecStart=/usr/bin/java $JAVA_ARGS \
           -XX:OnOutOfMemoryError=kill\ -9\ %p \
           -XX:+HeapDumpOnOutOfMemoryError \
           -XX:HeapDumpPath=/var/log/<%= EZBake::Config[:project] %> \
+          -Djava.security.egd=/dev/urandom \
           -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" clojure.main \
-          -m puppetlabs.trapperkeeper.main --config "${CONFIG}" \
+          -m <%= EZBake::Config[:main_namespace] %> \
+          --config "${CONFIG}" \
           -b "${BOOTSTRAP_CONFIG}" $@
 
 KillMode=process

--- a/template/foss/ext/redhat/ezbake.spec.erb
+++ b/template/foss/ext/redhat/ezbake.spec.erb
@@ -106,11 +106,14 @@ cp -pr ext/<%= EZBake::Config[:project] -%>.logrotate.conf %{buildroot}%{_syscon
 cp -pr ext/<%= EZBake::Config[:project] -%>.logrotate-legacy.conf %{buildroot}%{_sysconfdir}/logrotate.d/<%= EZBake::Config[:project] %>
 %endif
 
+install -d -m 700 %{buildroot}%{_localstatedir}/log/<%= EZBake::Config[:project] %>
+<% if EZBake::Config[:create_varlib] -%>
+install -d -m 700 %{buildroot}%{_localstatedir}/lib/<%= EZBake::Config[:project] %>
+<% end -%>
+
 <% EZBake::Config[:redhat][:additional_install].each do |install| -%>
 <%= install %>
 <% end -%>
-
-install -d -m 700 %{buildroot}%{_localstatedir}/log/<%= EZBake::Config[:project] %>
 
 <% unless EZBake::Config[:terminus_info].empty? -%>
 env DESTDIR=%{buildroot} rubylibdir=%{puppet_libdir} prefix=%{_prefix} make -e install-<%= EZBake::Config[:project] %>-termini
@@ -133,14 +136,27 @@ getent passwd <%= EZBake::Config[:user] %> > /dev/null || \
 
 %post
 %if %{_with_systemd}
+# Reload the systemd units if this is an upgrade
+if [ "$1" = "2" ]; then
+    systemctl daemon-reload >/dev/null 2>&1 || :
+    systemctl try-restart %{name}.service
+fi
 %systemd_post <%= EZBake::Config[:project] %>.service
 %else
 # If this is an install (as opposed to an upgrade)...
 if [ "$1" = "1" ]; then
-  # Register the <%= EZBake::Config[:project] %> service
-  /sbin/chkconfig --add %{name}
+    # Register the <%= EZBake::Config[:project] %> service
+    /sbin/chkconfig --add %{name}
+# If this is an upgrade, restart if we are already running
+elif [ "$1" = "2" ]; then
+    if /sbin/service %{name} status > /dev/null 2>&1; then
+        /sbin/service %{name} restart || :
+    fi
 fi
 %endif
+<% EZBake::Config[:redhat][:additional_postinst].each do |cmd| -%>
+<%= cmd %>
+<% end -%>
 
 %preun
 %if %{_with_systemd}
@@ -172,6 +188,9 @@ fi
 %files
 %defattr(-, root, root)
 %dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_localstatedir}/log/%{name}
+<% if EZBake::Config[:create_varlib] -%>
+%dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_localstatedir}/lib/%{name}
+<% end -%>
 <% if File.exists?("ext/docs") -%>
 %doc ext/docs
 <% end -%>
@@ -198,7 +217,7 @@ fi
 <% EZBake::Config[:terminus_info].each do |proj_name, info| -%>
 %defattr(-, root, root)
 <% info[:files].each do |file| -%>
-%{puppet_libdir}/<%= file -%>
+%{puppet_libdir}/<%= file %>
 <% end -%>
 <% end -%>
 <% end %>

--- a/template/foss/ext/redhat/init.erb
+++ b/template/foss/ext/redhat/init.erb
@@ -34,10 +34,10 @@ config=$CONFIG
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 JARFILE="<%= EZBake::Config[:uberjar_name] %>"
-JAVA_ARGS="${JAVA_ARGS} -jar ${INSTALL_DIR}/${JARFILE} --config ${CONFIG} --bootstrap-config ${BOOTSTRAP_CONFIG}"
+JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b '${BOOTSTRAP_CONFIG}'"
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile=/var/lock/subsys/$prog
-EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/$prog $JAVA_ARGS"
+EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/$prog -Djava.security.egd=/dev/urandom $JAVA_ARGS"
 PIDFILE="/var/run/$prog/$prog"
 START_TIMEOUT=${START_TIMEOUT:-60}
 


### PR DESCRIPTION
These changes represent the changes required to make PuppetDB use ezbake.
- PuppetDB uses its own namespace for -main function execution, so two new
  parameters were added to the ezbake configuration for each project to
  allow this to be overriden and custom arguments to be passed in.
- We have the need for the /var/lib/puppetdb directory, so we've added an
  option to automatically create this on a per project basis.
- All the necessary PuppetDB configuration files were created, with an eye
  to keep as much of it in the repository for PuppetDB as possible.
- Our termini code includes more than just puppet/indirector in its path,
  so we've expanded the included path for this.
- We want to keep our logback.xml and bootstrap.cfg in our repository for now,
  so we've included the entire config/ directory when transferring files
- Some of our configuration files in conf.d need templating, so now everything
  in that directory can be a template.
- puppetdb-ssl-setup is required to be ran, so we now include post install blocks
  for redhat and debian to allow for this in our configuration file.
- Some OpenBSD specific stuff has been transferred into the cli-app.erb template,
  as this was contributed by downstream authors and we think its a good idea to
  continue to support that use case.
- We had a slight ammendment to our `puppetdb` sub-command dispatcher that was
  not copied over to ezbake: --version. This feature now allows a user to type
  `puppetdb --version` to get a quick idea of the version of the package.
- We have synchronised all 3 stop/start scripts: debian init, redhat init and
  redhat systemd service so that they all use the 'skip-aot' compatible way
  of launching our clojure applications. Before this only the redhat systemd
  service definition used this. We need this, as we don't AOT in PuppetDB.
- We have switched to using /dev/urandom for java.security.egd to placate the
  SSL gods, and stop random waits on /dev/random for all our applications.
  PuppetDB has had this for some time, now its core.

Signed-off-by: Ken Barber ken@bob.sh
