### PR TITLE
(MAINT) Add explicit nrepl references

### DIFF
--- a/configs/classifier/classifier.clj
+++ b/configs/classifier/classifier.clj
@@ -3,7 +3,12 @@
   :pedantic? :abort
   :dependencies [[puppetlabs/classifier "{{{classifier-version}}}"]
                  [puppetlabs/pe-rbac-service "{{{pe-rbac-version}}}"]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.7.2"]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.7.2"]
+                 ;; There is a bug in leiningen that forces us to
+                 ;; explicitly reference nrepl if we want it to be
+                 ;; included in the uberjar.
+                 ;; https://github.com/technomancy/leiningen/issues/1762
+                 [org.clojure/tools.nrepl "0.2.3"]]
 
   :uberjar-name "classifier-release.jar"
 

--- a/configs/pe-classifier/pe-classifier.clj
+++ b/configs/pe-classifier/pe-classifier.clj
@@ -2,7 +2,12 @@
   :description "Release artifacts for classifier"
   :pedantic? :abort
   :dependencies [[puppetlabs/classifier "{{{pe-classifier-version}}}"]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.7.2"]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.7.2"]
+                 ;; There is a bug in leiningen that forces us to
+                 ;; explicitly reference nrepl if we want it to be
+                 ;; included in the uberjar.
+                 ;; https://github.com/technomancy/leiningen/issues/1762
+                 [org.clojure/tools.nrepl "0.2.3"]]
 
   :uberjar-name "classifier-release.jar"
 

--- a/configs/pe-console-services/pe-console-services.clj
+++ b/configs/pe-console-services/pe-console-services.clj
@@ -7,7 +7,12 @@
                  [puppetlabs/rbac-ui "{{{pe-rbac-ui-version}}}"]
                  [puppetlabs/pe-activity-service "{{{pe-activity-service-version}}}"]
                  [puppetlabs/pe-trapperkeeper-proxy "{{{pe-trapperkeeper-proxy-version}}}"]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.9.0"]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.9.0"]
+                 ;; There is a bug in leiningen that forces us to
+                 ;; explicitly reference nrepl if we want it to be
+                 ;; included in the uberjar.
+                 ;; https://github.com/technomancy/leiningen/issues/1762
+                 [org.clojure/tools.nrepl "0.2.3"]]
 
   :uberjar-name "console-services-release.jar"
 

--- a/configs/pe-puppetserver/pe-puppetserver.clj
+++ b/configs/pe-puppetserver/pe-puppetserver.clj
@@ -2,7 +2,12 @@
   :description "Release artifacts for pe-puppetserver"
   :pedantic? :abort
   :dependencies [[puppetlabs/pe-puppet-server-extensions "{{{pe-puppet-server-version}}}"]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.9.0"]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.9.0"]
+                 ;; There is a bug in leiningen that forces us to
+                 ;; explicitly reference nrepl if we want it to be
+                 ;; included in the uberjar.
+                 ;; https://github.com/technomancy/leiningen/issues/1762
+                 [org.clojure/tools.nrepl "0.2.3"]]
 
   :uberjar-name "puppet-server-release.jar"
 

--- a/configs/puppetserver/puppetserver.clj
+++ b/configs/puppetserver/puppetserver.clj
@@ -2,7 +2,12 @@
   :description "Release artifacts for puppet-server"
   :pedantic? :abort
   :dependencies [[puppetlabs/puppet-server "{{{puppet-server-version}}}"]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.9.0"]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "0.9.0"]
+                 ;; There is a bug in leiningen that forces us to
+                 ;; explicitly reference nrepl if we want it to be
+                 ;; included in the uberjar.
+                 ;; https://github.com/technomancy/leiningen/issues/1762
+                 [org.clojure/tools.nrepl "0.2.3"]]
 
   :uberjar-name "puppet-server-release.jar"
 


### PR DESCRIPTION
There appears to be a bug in leiningen where it will exclude
tools.nrepl from an uberjar if it is a transitive dependency of
your project (as opposed to a first-class dependency listed in
the project.clj file that you are building the uberjar from).

See https://github.com/technomancy/leiningen/issues/1762 .

This commit adds an explicit dependency to all of our ezbake
project config files, to make sure that we are including the
nrepl code in the uberjars.
