### PR TITLE
(PE-6711) Unify logging configs for pe services with the pe-module

### DIFF
--- a/configs/pe-console-services/config/logback.xml
+++ b/configs/pe-console-services/config/logback.xml
@@ -16,6 +16,8 @@
 
     <logger name="org.eclipse.jetty" level="INFO"/>
 
+    <logger name="org.apache.shiro" level="WARN"/>
+
     <root level="info">
         <!--<appender-ref ref="STDOUT"/>-->
         <appender-ref ref="F1"/>

--- a/configs/pe-console-services/config/request-logging.xml
+++ b/configs/pe-console-services/config/request-logging.xml
@@ -1,0 +1,9 @@
+<configuration debug="false">
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>/var/log/pe-console-services/console-services-access.log</file>
+    <encoder>
+      <pattern>%h %l %u %user %date "%r" %s %b</pattern>
+    </encoder>
+  </appender>
+  <appender-ref ref="FILE" />
+</configuration>

--- a/configs/pe-puppetserver/config/logback.xml
+++ b/configs/pe-puppetserver/config/logback.xml
@@ -6,7 +6,7 @@
     </appender>
 
     <appender name="F1" class="ch.qos.logback.core.FileAppender">
-        <file>/var/log/pe-puppetserver/pe-puppetserver.log</file>
+        <file>/var/log/pe-puppetserver/puppetserver.log</file>
         <append>true</append>
         <encoder>
             <pattern>%d %-5p [%c{2}] %m%n</pattern>


### PR DESCRIPTION
This commit updates the logging configs for pe-puppetserver and
pe-console-services to be the configs we intend to use in production so
that we don't need to manage them using puppet or lay down new ones in
the installer. This way when a user need not wait for puppet to run in
order to see logging changes for pe services.
