### PR TITLE
(TK-112) Add foreground command to all projects

### DIFF
--- a/configs/pe-classifier/config/logback.xml
+++ b/configs/pe-classifier/config/logback.xml
@@ -18,6 +18,7 @@
 
     <root level="info">
         <!--<appender-ref ref="STDOUT"/>-->
+        <appender-ref ref="${logappender:-DUMMY}" />
         <appender-ref ref="F1"/>
     </root>
 </configuration>

--- a/configs/pe-console-services/config/logback.xml
+++ b/configs/pe-console-services/config/logback.xml
@@ -20,6 +20,7 @@
 
     <root level="info">
         <!--<appender-ref ref="STDOUT"/>-->
+        <appender-ref ref="${logappender:-DUMMY}" />
         <appender-ref ref="F1"/>
     </root>
 </configuration>

--- a/configs/pe-puppetserver/config/logback.xml
+++ b/configs/pe-puppetserver/config/logback.xml
@@ -17,6 +17,7 @@
 
     <root level="info">
         <!--<appender-ref ref="STDOUT"/>-->
+        <appender-ref ref="${logappender:-DUMMY}" />
         <appender-ref ref="F1"/>
     </root>
 </configuration>

--- a/configs/puppetserver/config/logback.xml
+++ b/configs/puppetserver/config/logback.xml
@@ -18,6 +18,7 @@
 
     <root level="info">
         <!--<appender-ref ref="STDOUT"/>-->
+        <appender-ref ref="${logappender:-DUMMY}" />
         <appender-ref ref="F1"/>
     </root>
 </configuration>

--- a/template/global/ext/cli/foreground.erb
+++ b/template/global/ext/cli/foreground.erb
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+if !(echo "${@}" | grep -e "--debug" -q)
+then
+    LOG_APPENDER="-Dlogappender=STDOUT"
+fi
+
+pushd "${INSTALL_DIR}" &> /dev/null
+su ${USER} -s /bin/bash -c "${JAVA_BIN} ${JAVA_ARGS} ${LOG_APPENDER} \
+        -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> \
+        clojure.main -m <%= EZBake::Config[:main_namespace] %> \
+        --config ${CONFIG} --bootstrap-config ${BOOTSTRAP_CONFIG} \
+        ${@}"
+popd &> /dev/null


### PR DESCRIPTION
This PR adds a `foreground` cli command to all projects built with ezbake. Additionally, it provides the ability to easily add new global cli commands by adding templates to `template/global/ext/cli'.

I tested the foreground command with a build of Puppet Server on Debian 7, CentOS 6, and CentOS 7. I can test with a build of another project if it's deemed necessary.
