### PR TITLE
(MAINT) Add reverse-proxy CA service route

### DIFF
--- a/configs/pe-puppetserver/config/conf.d/web-routes.conf
+++ b/configs/pe-puppetserver/config/conf.d/web-routes.conf
@@ -3,8 +3,11 @@ web-router-service: {
     # the Puppet 3.x agent expects them to be mounted at "/".
     "puppetlabs.services.master.master-service/master-service": ""
 
-    # To disable the CA service, remove this line.
+    # This controls the mount point for the CA service.
     "puppetlabs.services.ca.certificate-authority-service/certificate-authority-service": ""
+
+    # This controls the mount point for the reverse-proxy CA service
+    "puppetlabs.enterprise.services.reverse-proxy.reverse-proxy-ca-service/reverse-proxy-ca-service": ""
 
     # This controls the mount point for the puppet admin API.
     "puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service": "/puppet-admin-api"


### PR DESCRIPTION
Add a route for the reverse-proxy CA service to the PE
Puppet Server configuration.
