### PR TITLE
(re-3507) Changes to make pe-puppetdb work with ezbake

### DIFF
--- a/configs/pe-puppetdb/pe-puppetdb.clj
+++ b/configs/pe-puppetdb/pe-puppetdb.clj
@@ -1,0 +1,19 @@
+(defproject puppetlabs.packages/pe-puppetdb "{{{pe-puppetdb-version}}}"
+  :description "Release artifacts for pe-puppetdb"
+  :pedantic? :abort
+  :dependencies [[puppetlabs/puppetdb "{{{pe-puppetdb-version}}}"]
+                 ;; This is intended to work around what we believe is a
+                 ;; leiningen bug. Otherwise tools.nrepl gets stripped out by
+                 ;; leiningen: https://github.com/technomancy/leiningen/issues/1762
+                 [org.clojure/tools.nrepl "0.2.3"]]
+
+  :uberjar-name "puppetdb-release.jar"
+
+  :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]
+                 ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
+
+  :ezbake {:user "pe-puppetdb"
+           :group "pe-puppetdb"
+           :build-type "pe"
+           :main-namespace "puppetlabs.puppetdb.main"
+           :create-varlib true})

--- a/template/pe/ext/debian/dirs.erb
+++ b/template/pe/ext/debian/dirs.erb
@@ -1,1 +1,4 @@
 var/log/<%= EZBake::Config[:project] %>
+<% if EZBake::Config[:create_varlib] -%>
+var/lib/<%= EZBake::Config[:project] %>
+<% end -%>

--- a/template/pe/ext/debian/ezbake.init.erb
+++ b/template/pe/ext/debian/ezbake.init.erb
@@ -31,9 +31,9 @@ PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 START_TIMEOUT=${START_TIMEOUT:-60}
 
-JAVA_ARGS="${JAVA_ARGS} -jar ${INSTALL_DIR}/${JARFILE} --config ${CONFIG} --bootstrap-config ${BOOTSTRAP_CONFIG}"
+JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b '${BOOTSTRAP_CONFIG}'"
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
-EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/$NAME $JAVA_ARGS"
+EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/$NAME -Djava.security.egd=/dev/urandom $JAVA_ARGS"
 
 # Exit if the package is not installed
 [ -x "$JAVA_BIN" ] || exit 0

--- a/template/pe/ext/debian/postinst.erb
+++ b/template/pe/ext/debian/postinst.erb
@@ -2,3 +2,11 @@
 
 chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> /var/log/<%= EZBake::Config[:project] %>
 chmod 700 /var/log/<%= EZBake::Config[:project] %>
+<% if EZBake::Config[:create_varlib] -%>
+chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> /var/lib/<%= EZBake::Config[:project] %>
+chmod 700 /var/lib/<%= EZBake::Config[:project] %>
+<% end -%>
+
+<% EZBake::Config[:debian][:additional_postinst].each do |cmd| -%>
+<%= cmd %>
+<% end -%>

--- a/template/pe/ext/debian/rules.erb
+++ b/template/pe/ext/debian/rules.erb
@@ -12,6 +12,8 @@ export prefix=/opt/puppet
 export bindir=/opt/puppet/bin
 export rubylibdir
 export confdir=/etc/puppetlabs
+export datadir=$(prefix)/share
+export sharedstatedir=/var/lib
 export realname=<%= EZBake::Config[:real_name] %>
 
 install/<%= EZBake::Config[:project] %>::

--- a/template/pe/ext/redhat/ezbake.service.erb
+++ b/template/pe/ext/redhat/ezbake.service.erb
@@ -12,8 +12,10 @@ ExecStart=/opt/puppet/bin/java $JAVA_ARGS \
           -XX:OnOutOfMemoryError=kill\ -9\ %p \
           -XX:+HeapDumpOnOutOfMemoryError \
           -XX:HeapDumpPath=/var/log/<%= EZBake::Config[:project] %> \
+          -Djava.security.egd=/dev/urandom \
           -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" clojure.main \
-          -m puppetlabs.trapperkeeper.main --config "${CONFIG}" \
+          -m <%= EZBake::Config[:main_namespace] %> \
+          --config "${CONFIG}" \
           -b "${BOOTSTRAP_CONFIG}" $@
 
 KillMode=process

--- a/template/pe/ext/redhat/ezbake.spec.erb
+++ b/template/pe/ext/redhat/ezbake.spec.erb
@@ -161,11 +161,14 @@ cp -p ext/<%= EZBake::Config[:project] -%>.logrotate.conf %{buildroot}%{_real_sy
 cp -p ext/<%= EZBake::Config[:project] -%>.logrotate-legacy.conf %{buildroot}%{_real_sysconfdir}/logrotate.d/<%= EZBake::Config[:project] %>
 %endif
 
+install -d -m 700 %{buildroot}%{_localstatedir}/log/<%= EZBake::Config[:project] %>
+<% if EZBake::Config[:create_varlib] -%>
+install -d -m 700 %{buildroot}%{_localstatedir}/lib/<%= EZBake::Config[:project] %>
+<% end -%>
+
 <% EZBake::Config[:redhat][:additional_install].each do |install| -%>
 <%= install %>
 <% end -%>
-
-install -d -m 700 %{buildroot}%{_localstatedir}/log/<%= EZBake::Config[:project] %>
 
 <% unless EZBake::Config[:terminus_info].empty? -%>
 env DESTDIR=%{buildroot} rubylibdir=%{puppet_libdir} prefix=%{_prefix} make -e install-<%= EZBake::Config[:project] %>-termini
@@ -187,6 +190,13 @@ getent passwd <%= EZBake::Config[:user] %> > /dev/null || \
 <% end -%>
 
 %post
+%if %{_with_systemd}
+# Reload the systemd units if this is an upgrade
+if [ "$1" = "2" ]; then
+    systemctl daemon-reload >/dev/null 2>&1 || :
+    systemctl try-restart %{name}.service
+fi
+%endif
 %if %{_systemd_el}
 %systemd_post <%= EZBake::Config[:project] %>.service
 %endif
@@ -196,10 +206,18 @@ getent passwd <%= EZBake::Config[:user] %> > /dev/null || \
 %if %{_with_sysvinit}
 # If this is an install (as opposed to an upgrade)...
 if [ "$1" = "1" ]; then
-  # Register the <%= EZBake::Config[:project] %> service
-  /sbin/chkconfig --add %{name}
+    # Register the <%= EZBake::Config[:project] %> service
+    /sbin/chkconfig --add %{name}
+# If this is an upgrade, restart if we are already running
+elif [ "$1" = "2" ]; then
+    if /sbin/service %{name} status > /dev/null 2>&1; then
+        /sbin/service %{name} restart || :
+    fi
 fi
 %endif
+<% EZBake::Config[:redhat][:additional_postinst].each do |cmd| -%>
+<%= cmd %>
+<% end -%>
 
 %preun
 %if %{_systemd_el}
@@ -239,6 +257,9 @@ fi
 %files
 %defattr(-, root, root)
 %dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_localstatedir}/log/%{name}
+<% if EZBake::Config[:create_varlib] -%>
+%dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_localstatedir}/lib/%{name}
+<% end -%>
 <% if File.exists?("ext/docs") %>
 %doc ext/docs
 <% end %>
@@ -264,7 +285,7 @@ fi
 <% EZBake::Config[:terminus_info].each do |proj_name, info| -%>
 %defattr(-, root, root)
 <% info[:files].each do |file| -%>
-%{puppet_libdir}/<%= file -%>
+%{puppet_libdir}/<%= file %>
 <% end -%>
 <% end -%>
 <% end %>

--- a/template/pe/ext/redhat/init.erb
+++ b/template/pe/ext/redhat/init.erb
@@ -34,10 +34,10 @@ config=$CONFIG
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 JARFILE="<%= EZBake::Config[:uberjar_name] %>"
-JAVA_ARGS="${JAVA_ARGS} -jar ${INSTALL_DIR}/${JARFILE} --config ${CONFIG} --bootstrap-config ${BOOTSTRAP_CONFIG}"
+JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b '${BOOTSTRAP_CONFIG}'"
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile=/var/lock/subsys/$prog
-EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/$prog $JAVA_ARGS"
+EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/$prog -Djava.security.egd=/dev/urandom $JAVA_ARGS"
 PIDFILE="/var/run/$prog/$prog"
 START_TIMEOUT=${START_TIMEOUT:-60}
 

--- a/template/pe/ext/redhat/init.suse.erb
+++ b/template/pe/ext/redhat/init.suse.erb
@@ -34,7 +34,8 @@ config=$CONFIG
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 JARFILE="<%= EZBake::Config[:uberjar_name] %>"
-JAVA_ARGS="${JAVA_ARGS} -jar ${INSTALL_DIR}/${JARFILE} --config ${CONFIG} --bootstrap-config ${BOOTSTRAP_CONFIG}"
+JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b '${BOOTSTRAP_CONFIG}'"
+EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile="/var/lock/subsys/${prog}"
 PIDFILE="/var/run/${prog}/${prog}.pid"
 LOGFILE="/var/log/${prog}/${prog}.log"
@@ -56,7 +57,7 @@ start() {
     echo -n $"Starting ${prog}: "
     export HOME="$(getent passwd ${USER} | cut -d':' -f6)"
     pushd ${INSTALL_DIR} &> /dev/null
-    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}" ${JAVA_ARGS}
+    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}" -Djava.security.egd=/dev/urandom ${JAVA_ARGS}
     rc_status -v
 
     <% if not EZBake::Config[:redhat][:post_start_action].empty? -%>


### PR DESCRIPTION
This is essentially a straight copy of the work from
https://github.com/puppetlabs/ezbake/pull/138 adapted
for PE builds.

The only additional change was updating the SLES init
script that only exists for PE.
