### PR TITLE
(PE-7080) Fix quoting on SuSE init script

### DIFF
--- a/template/pe/ext/redhat/init.suse.erb
+++ b/template/pe/ext/redhat/init.suse.erb
@@ -57,7 +57,7 @@ start() {
     echo -n $"Starting ${prog}: "
     export HOME="$(getent passwd ${USER} | cut -d':' -f6)"
     pushd ${INSTALL_DIR} &> /dev/null
-    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}" -Djava.security.egd=/dev/urandom ${JAVA_ARGS}
+    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog} -Djava.security.egd=/dev/urandom ${JAVA_ARGS}"
     rc_status -v
 
     <% if not EZBake::Config[:redhat][:post_start_action].empty? -%>


### PR DESCRIPTION
Misquoting was causing problems with JAVA_ARGS.

This fixes the quoting to match the other platforms.
