### PR TITLE
(EZ-25) Fix suse init.d start errors

### DIFF
--- a/template/pe/ext/redhat/init.suse.erb
+++ b/template/pe/ext/redhat/init.suse.erb
@@ -34,7 +34,7 @@ config=$CONFIG
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 JARFILE="<%= EZBake::Config[:uberjar_name] %>"
-JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b '${BOOTSTRAP_CONFIG}'"
+JAVA_ARGS="${JAVA_ARGS} -cp ${INSTALL_DIR}/${JARFILE} clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b ${BOOTSTRAP_CONFIG}"
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile="/var/lock/subsys/${prog}"
 PIDFILE="/var/run/${prog}/${prog}.pid"
@@ -57,7 +57,7 @@ start() {
     echo -n $"Starting ${prog}: "
     export HOME="$(getent passwd ${USER} | cut -d':' -f6)"
     pushd ${INSTALL_DIR} &> /dev/null
-    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog} -Djava.security.egd=/dev/urandom ${JAVA_ARGS}"
+    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog} -Djava.security.egd=/dev/urandom" ${JAVA_ARGS}
     rc_status -v
 
     <% if not EZBake::Config[:redhat][:post_start_action].empty? -%>


### PR DESCRIPTION
Previous to this commit, the init.d script generated by ezbake would
fail to start the java service due to misquoted args. This commit fixes
it by bringing it in line with the other redhat init script:

remove single quote around the class path java arg
remove single quote around the bootstrap config java arg
place the JAVA_ARGS variable outside the quotes on the startproc call
