### PR TITLE
(SERVER-275) Fix Puppet Server logback files

### DIFF
--- a/configs/pe-puppetserver/config/logback.xml
+++ b/configs/pe-puppetserver/config/logback.xml
@@ -1,4 +1,4 @@
-<configuration>
+<configuration scan="true">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %-5p [%c{2}] %m%n</pattern>

--- a/configs/puppetserver/config/logback.xml
+++ b/configs/puppetserver/config/logback.xml
@@ -1,4 +1,4 @@
-<configuration>
+<configuration scan="true">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %-5p [%c{2}] %m%n</pattern>


### PR DESCRIPTION
Add scan="true" to both the PE and FOSS Puppet Server logback
files so that changes to the logback files are reflected without
having to restart the service.
