### PR TITLE
(PE-7274) Update pe-console-services logback files

### DIFF
--- a/configs/pe-puppetserver/config/logback.xml
+++ b/configs/pe-puppetserver/config/logback.xml
@@ -1,4 +1,4 @@
-<configuration>
+<configuration scan="true">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %-5p [%c{2}] %m%n</pattern>

--- a/configs/puppetserver/config/logback.xml
+++ b/configs/puppetserver/config/logback.xml
@@ -1,4 +1,4 @@
-<configuration>
+<configuration scan="true">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %-5p [%c{2}] %m%n</pattern>


### PR DESCRIPTION
Add scan="true" to the pe-console-services logback files so that
changes to the logback file will be reflected without a service
restart.

This is the same as https://github.com/puppetlabs/ezbake/pull/162, except targeted at `puppetserver/stable` so that the change will get into 1.0.1.
