### PR TITLE
(maint) Set update always policy for ezbake for PuppetDB

### DIFF
--- a/configs/puppetdb/puppetdb.clj
+++ b/configs/puppetdb/puppetdb.clj
@@ -10,7 +10,8 @@
   :uberjar-name "puppetdb-release.jar"
 
   :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]
-                 ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
+                 ["snapshots" {:url "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"
+                               :update :always}]]
 
   :ezbake {:user "puppetdb"
            :group "puppetdb"


### PR DESCRIPTION
Without this, we only download one version a day and so our tests are running
against stale code.

Signed-off-by: Ken Barber ken@bob.sh
