### PR TITLE
(MAINT) Make foreground cli command more robust

### DIFF
--- a/template/global/ext/cli/foreground.erb
+++ b/template/global/ext/cli/foreground.erb
@@ -6,7 +6,7 @@ then
 fi
 
 pushd "${INSTALL_DIR}" &> /dev/null
-su ${USER} -s /bin/bash -c "${JAVA_BIN} ${JAVA_ARGS} ${LOG_APPENDER} \
+su "${USER}" -s /bin/bash -c "${JAVA_BIN} ${JAVA_ARGS} ${LOG_APPENDER} \
         -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> \
         clojure.main -m <%= EZBake::Config[:main_namespace] %> \
         --config ${CONFIG} --bootstrap-config ${BOOTSTRAP_CONFIG} \


### PR DESCRIPTION
Make the foreground cli command more robust by adding quotes
around the ${USER} variable.

This implements the changes suggested by @jeffmccune in https://github.com/puppetlabs/pe-puppet-server-extensions/pull/162. I felt it belonged in 3.7.2, since it's a minor change and the changes to pe-puppet-server are also going into 3.7.2.
