### PR TITLE
(re-3691) Start services after pe-postgresql

### DIFF
--- a/template/foss/ext/redhat/init.erb
+++ b/template/foss/ext/redhat/init.erb
@@ -2,7 +2,7 @@
 #
 # Puppet Labs <%= EZBake::Config[:project] %>
 #
-# chkconfig: - 20 80
+# chkconfig: - 70 10
 # description: Puppet Labs <%= EZBake::Config[:project] %>
 
 ### BEGIN INIT INFO

--- a/template/pe/ext/debian/ezbake.init.erb
+++ b/template/pe/ext/debian/ezbake.init.erb
@@ -5,6 +5,8 @@
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
+# Should-Start:      pe-postgresql
+# Should-Stop:       pe-postgresql
 # Short-Description: <%= EZBake::Config[:project] %>
 # Description:       Start <%= EZBake::Config[:project] %> daemon placed in /etc/init.d.
 ### END INIT INFO

--- a/template/pe/ext/redhat/ezbake.service.erb
+++ b/template/pe/ext/redhat/ezbake.service.erb
@@ -1,6 +1,6 @@
 [Unit]
 Description=<%= EZBake::Config[:project] %> Service
-After=syslog.target network.target
+After=syslog.target network.target pe-postgresql.service
 
 [Service]
 Type=simple

--- a/template/pe/ext/redhat/init.erb
+++ b/template/pe/ext/redhat/init.erb
@@ -2,7 +2,7 @@
 #
 # Puppet Labs <%= EZBake::Config[:project] %>
 #
-# chkconfig: - 20 80
+# chkconfig: - 70 10
 # description: Puppet Labs <%= EZBake::Config[:project] %>
 
 ### BEGIN INIT INFO

--- a/template/pe/ext/redhat/init.suse.erb
+++ b/template/pe/ext/redhat/init.suse.erb
@@ -2,7 +2,7 @@
 #
 # Puppet Labs <%= EZBake::Config[:project] %>
 #
-# chkconfig: - 20 80
+# chkconfig: - 70 10
 # description: Puppet Labs <%= EZBake::Config[:project] %>
 
 ### BEGIN INIT INFO


### PR DESCRIPTION
Some of our services depend on PostgreSQL being available at
start time.

This adds ordering to the startup scripts such that services
should start after pe-postgresql, if it is configured
to run on the local server.
