### PR TITLE
(PE-7614) Fix SLES-11 pe-puppetserver init script

### DIFF
--- a/template/global/ext/ezbake-functions.sh.erb
+++ b/template/global/ext/ezbake-functions.sh.erb
@@ -16,24 +16,23 @@ wait_for_app()
 
         # verify the process is still running; if not, return failure
         ps -p $pid 2>&1 > /dev/null
-        if [ ! "$?" -eq 0 ] ;then
+        if [ "$?" != 0 ]; then
             return 1
         fi
 
         # if there are any TCP ports associated with the process, return success
-        netstat -tulpn 2>/dev/null | grep $pid 2>&1 >/dev/null
-        if [ "$?" -eq 0 ] ;then
+        netstat -tulpn 2>/dev/null | grep "$pid" 2>&1 >/dev/null
+        if [ "$?" = 0 ]; then
             return 0
         fi
 
         # if we reach the timeout, return failure
-        if [ "$timeout" -eq 0 ] ;then
+        if [ "$timeout" = 0 ]; then
             return 1
         fi
 
         sleep 1
         timeout=$(($timeout-1))
-
     done
 }
 

--- a/template/pe/ext/redhat/init.suse.erb
+++ b/template/pe/ext/redhat/init.suse.erb
@@ -34,67 +34,100 @@ config=$CONFIG
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 JARFILE="<%= EZBake::Config[:uberjar_name] %>"
-JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b '${BOOTSTRAP_CONFIG}'"
+JAVA_ARGS="${JAVA_ARGS} -cp ${INSTALL_DIR}/${JARFILE} clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b ${BOOTSTRAP_CONFIG}"
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile="/var/lock/subsys/${prog}"
 PIDFILE="/var/run/${prog}/${prog}.pid"
 LOGFILE="/var/log/${prog}/${prog}.log"
-START_TIMEOUT=${START_TIMEOUT:-60}
+START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 
 # First reset status of this service
 rc_reset
 
-find_my_pid() {
+print_service_pid() {
+    local pid
     if [ ! -d  "/var/run/${prog}" ] ; then
         install --owner "${USER}" --group "${USER}" --directory "/var/run/${prog}"
     fi
     pid="$(pgrep -f "${JAVA_BIN}.*${JARFILE}")"
+    echo -n "${pid}"
 }
 
 start() {
+    local service_pid
     [ -x "${JAVA_BIN}" ] || exit 5
     [ -e "${config}" ] || exit 6
     echo -n $"Starting ${prog}: "
     export HOME="$(getent passwd ${USER} | cut -d':' -f6)"
-    pushd ${INSTALL_DIR} &> /dev/null
+    # startproc will change users, so make sure that user has permission
+    # to access the present working directory.
+    cd "${INSTALL_DIR}"
     startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}" -Djava.security.egd=/dev/urandom ${JAVA_ARGS}
     rc_status -v
+    retval=$?
+
+    # NOTE: retval holds the return value of `startproc`, not the process
+    # started by `startproc`.
+
+    # If rc_status didn't succeed, bail out early without bothering to poll
+    # waiting for the application or doing work that assumes a launching state
+    if [ "$retval" != 0 ]; then
+        log_failure_msg $"${prog} startup"
+        echo
+        return $retval
+    fi
+
+    service_pid="$(print_service_pid)"
+    echo -n "${service_pid}" > "${PIDFILE}"
 
     <% if not EZBake::Config[:redhat][:post_start_action].empty? -%>
-    if [ "$?" -eq 0]; then
-    <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
+    if [ "$retval" = 0 ]; then
+        <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
         <%= action %>
-    <% end -%>
+        <% end -%>
     fi
     <% end -%>
 
-    sleep 1
-    popd &> /dev/null
-    find_my_pid
-    echo "${pid}" > "${PIDFILE}"
-    [ -s "${PIDFILE}" ] && log_success_msg $"${prog} startup" || log_failure_msg $"${prog} startup"
-    echo
-    [ -s "${PIDFILE}" ] && touch "${lockfile}"
+    # Wait for the application to become available
+    if ! wait_for_app "${service_pid}" "$START_TIMEOUT"; then
+        log_failure_msg $"${prog} startup"
+        echo
+        return 1
+    fi
 
-    if [ "$retval" -eq 0 ] && ! wait_for_app $(cat $PIDFILE) $START_TIMEOUT ;then
-        log_failure_msg $"$base startup"
+    # if the pid file exists, with the PID in it (non-zero size)
+    if [ -s "${PIDFILE}" ]; then
+        log_success_msg $"${prog} startup"
+        echo
+        touch "${lockfile}"
+        return 0
+    else
+        log_failure_msg $"${prog} startup"
+        echo
+        return 1
     fi
 }
 
 stop() {
     echo -n $"Stopping ${prog}: "
-    find_my_pid
-
     if [ ! -s "${PIDFILE}" ] ; then
-        echo "${pid}" > "${PIDFILE}"
+        print_service_pid > "${PIDFILE}"
     fi
 
     killproc -p "${PIDFILE}" -t"${SERVICE_STOP_RETRIES}"s -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}" "${JAVA_ARGS}"
     rc_status -v
     retval=$?
-    [ $retval -eq 0 ] && log_success_msg $"${prog} stopped" || log_failure_msg $"${prog} stopped"
-    echo
-    [ $retval -eq 0 ] && rm -f "${lockfile}" "${PIDFILE}"
+
+    if [ "$retval" = 0 ]; then
+        rm -f "${lockfile}" "${PIDFILE}"
+        log_success_msg $"${prog} stopped"
+        echo
+        return 0
+    else
+        log_failure_msg $"${prog} could not be stopped, check ${LOGFILE}"
+        echo
+        return 1
+    fi
 }
 
 restart() {
@@ -115,14 +148,14 @@ sl_status() {
 case "$1" in
     start)
         sl_status_q && exit 0
-        $1
+        start
         ;;
     stop)
         sl_status_q || exit 0
-        $1
+        stop
         ;;
     restart)
-        $1
+        restart
         ;;
     condrestart|try-restart)
         sl_status_q || exit 0


### PR DESCRIPTION
Without this patch the pe-puppetserver service in PE fails to start on SLES-11.

The root cause of the issue is that the JAVA_ARGS string contains sub-strings
which are intended to be positional arguments.  Because the complete string is
used when invoking a command, BASH expands the string into positional arguments
without considering the inner quotes.  The following behavior illustrates the
problem in bash:

```
$ JAVA_ARGS="a b '/path' '/spa ce'"; ruby -e 'puts ARGV.inspect' $JAVA_ARGS
["a", "b", "'/path'", "'/spa", "ce'"]
```

The desire is for the path positional arguments to be correct with or without
spaces, but the actual behavior is that a path without spaces is received with
surrounding single quotes and a path with spaces is broken into two separate
arguments.

In addition to this root cause, there are a number of other issues this patch
addresses:

Using the status method of the service results in error messages:

```
$ sudo /etc/init.d/pe-puppetserver status
checkproc: Can not handle pid file /var/run/pe-puppetserver/pe-puppetserver.pid with pid `'
                                               dead
```

This error is caused by $pid being unbound, presumably because the java process
never starts.  The script prints the unbound $pid variable with a trailing
newline to $PIDFILE.  This newline caused all of the `[ -s "${PIDFILE}" ]`
guard checks to pass when they should have failed because the -s test returns
true when the file has a non-zero size.

In addition to this error, there are other issues that prevent the script from
parsing correctly.  For example, making a surgical fix with focus on only
$retval, and $pid the following is still returned by `sudo
/etc/init.d/pe-puppetserver start`:

```
/etc/init.d/pe-puppetserver: line 63: [: missing `]'
```

And the following is returned by `sudo /etc/init.d/pe-puppetserver stop`:

```
/etc/init.d/pe-puppetserver: line 75: [: : integer expression expected
```

Given this cluster of issues, this patch resolves the problem by applying the
following changes.

Make sure $retval is bound immediately after calls to `rc_status`
because the subsequent code makes assumptions that it is bound and
contains an integer value.

Fail early when the return value of `rc_status` is non-zero because the
PID likely never started or died quickly.  Failing early prevents other
guard checks from executing unpredictably and focuses on the concern of
starting and checking the process via the PID.  If the script does not
fail early, errors and warnings as the script proceeds unpredictably
make troubleshooting more difficult.

More minor changes, but relevant to the errors encountered:

In general, replace `[ "$retval" -eq 0 ]` with `[ "$retval" = 0 ]`
because the latter behaves as expected when $retval is unbound or
contains a non-integer value.  The use of `-eq` with a string is less
robust because it returns `integer expression expected` for strings that
don't look like integers.

In general, replace `echo "${pid}" > "${PIDFILE}"` with `echo -n "${pid}" ...`
in an effort to be more robust with the pattern of using `[ -s "${PIDFILE}" ]`
because `echo` without `-n` will always send at least one byte, a newline, to
the file and `-s` tests against a non-zero size, which will never happen
without the `-n`.

In general, quote all bare variables passed as positional arguments because the
size of the argument vector changes if the variable is unbound without the
quotes.  This change is more robust when using fixed positional arguments as is
the case with functions like `wait_for_app`.
