### PR TITLE
(PDB-1034) Honor local-repo for aether requests

### DIFF
--- a/src/puppetlabs/ezbake/dependency_utils.clj
+++ b/src/puppetlabs/ezbake/dependency_utils.clj
@@ -32,7 +32,8 @@
   {:post [(instance? JarFile %)]}
   (-> (aether/resolve-artifacts
         :coordinates [coords]
-        :repositories (:repositories lein-project))
+        :repositories (:repositories lein-project)
+        :local-repo (:local-repo lein-project))
       first
       meta
       :file


### PR DESCRIPTION
The call to aether/resolve-artifacts wasn't honoring our :local-repo
override in our project. This patch will ensure we can use local-repo
and the effects will ripple into aether also.

Without this, when trying to do source based builds using the local
m2-local repositories, it will try and retrieve a copy of your projects
jar from maven for resource content, ignoring any local-repo setting you
might have defined. In short, this generally means any terminus files
and non-clojure items won't reflect the proper changes.

Signed-off-by: Ken Barber ken@bob.sh
