### PR TITLE
(SERVER-338) Add net-tools dependency for service unit files

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/control.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/control.erb
@@ -8,7 +8,9 @@ Homepage: http://puppetlabs.com
 
 Package: <%= EZBake::Config[:project] %>
 Architecture: all
-Depends: ${misc:Depends}, java7-runtime-headless, adduser<%=
+# net-tools is required for netstat usage in service unit file
+# See: https://tickets.puppetlabs.com/browse/SERVER-338
+Depends: ${misc:Depends}, java7-runtime-headless, net-tools, adduser<%=
     if !EZBake::Config[:debian][:additional_dependencies].empty?
       ", " + EZBake::Config[:debian][:additional_dependencies].join(", ")
     end %>

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -54,6 +54,9 @@ Requires:         chkconfig
 %endif
 
 Requires:         %{open_jdk}
+# net-tools is required for netstat usage in service unit file
+# See: https://tickets.puppetlabs.com/browse/SERVER-338
+Requires:         net-tools
 <% EZBake::Config[:redhat][:additional_dependencies].each do |dep| %>
 Requires:         <%= dep %>
 <% end %>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/control.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/control.erb
@@ -8,7 +8,9 @@ Homepage: http://puppetlabs.com
 
 Package: <%= EZBake::Config[:project] %>
 Architecture: all
-Depends: ${misc:Depends}, pe-java, adduser<%=
+# net-tools is required for netstat usage in service unit file
+# See: https://tickets.puppetlabs.com/browse/SERVER-338
+Depends: ${misc:Depends}, pe-java, net-tools, adduser<%=
     if !EZBake::Config[:debian][:additional_dependencies].empty?
       ", " + EZBake::Config[:debian][:additional_dependencies].join(", ")
     end %>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -104,6 +104,9 @@ Requires(postun): systemd
 %endif
 
 Requires:         pe-java
+# net-tools is required for netstat usage in service unit file
+# See: https://tickets.puppetlabs.com/browse/SERVER-338
+Requires:         net-tools
 <% EZBake::Config[:redhat][:additional_dependencies].each do |dep| %>
 Requires:         <%= dep %>
 <% end %>


### PR DESCRIPTION
Without this patch the init scripts and unit files make calls to netstat, which
may or may not exist on the system.  This is a problem because the service will
fail to start if netstat is not present.  This patch addresses the problem by
expressing net-tools as a dependency of the packages which will ensure netstat
is present prior to service management.

This patch has been merged into the 0.1.2 tag, but it never landed in one of
the branches being actively developed.  This pull request is to ensure the
change doesn't get lost in future versions of ezbake.
