### PR TITLE
(pe-7929) Add ability to create arbitrary dirs

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -10,6 +10,7 @@ module EZBake
       :cli_app_files  => [{{{cli-app-files}}}],
       :bin_files      => [{{{bin-files}}}],
       :create_varlib  => {{create-varlib}},
+      :create_dirs    => [{{{create-dirs}}}],
       :terminus_info  => {
                           {{#terminus-map}}
                             "{{{name}}}" => {

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -124,6 +124,9 @@ function task_install {
 <% if EZBake::Config[:create_varlib] -%>
     install -d -m 700 "${DESTDIR}${localstatedir}/lib/<%= EZBake::Config[:project] %>"
 <% end -%>
+<% EZBake::Config[:create_dirs].each do |dir| -%>
+    install -d -m 700 "${DESTDIR}<%= dir %>"
+<% end -%>
 }
 
 function task_install_redhat {
@@ -257,6 +260,10 @@ function task_postinst_permissions {
 <% if EZBake::Config[:create_varlib] -%>
     chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> /var/lib/<%= EZBake::Config[:project] %>
     chmod 700 /var/lib/<%= EZBake::Config[:project] %>
+<% end -%>
+<% EZBake::Config[:create_dirs].each do |dir| -%>
+    chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> <%= dir %>
+    chmod 700 <%= dir %> %>
 <% end -%>
 }
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -246,6 +246,9 @@ fi
 <% if EZBake::Config[:create_varlib] -%>
 %dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_localstatedir}/lib/%{name}
 <% end -%>
+<% EZBake::Config[:create_dirs].each do |dir| -%>
+%dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) <%= dir %>
+<% end -%>
 <% if File.exists?("ext/docs") %>
 %doc ext/docs
 <% end %>
@@ -279,4 +282,3 @@ fi
 %changelog
 * <%= Time.now.strftime("%a %b %d %Y") %> Puppet Labs Release <info@puppetlabs.com> -  <%= @rpmversion %>-<%= @rpmrelease %>
 - Build for <%= @version %>
-

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -381,6 +381,8 @@ Bundled packages: %s
          :create-varlib             (str (boolean (get-local-ezbake-var lein-project
                                                                         :create-varlib
                                                                         false)))
+         :create-dirs               (quoted-list (get-local-ezbake-var lein-project
+                                                                       :create-dirs []))
          :debian-deps               (get-quoted-ezbake-values :debian :dependencies)
          :debian-preinst            (get-quoted-ezbake-values :debian :preinst)
          :debian-postinst           (get-quoted-ezbake-values :debian :postinst)


### PR DESCRIPTION
pe-cpnsole-services has expressed the need for an application
var/cache directory.

This adds a facility to create arbitrary directories, owned by the
application user.
