### PR TITLE
(SERVER-344) Use runuser instead of su with foreground

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
@@ -6,7 +6,7 @@ then
 fi
 
 pushd "${INSTALL_DIR}" &> /dev/null
-su "${USER}" -s /bin/bash -c "${JAVA_BIN} ${JAVA_ARGS} ${LOG_APPENDER} \
+runuser "${USER}" -s /bin/bash -c "${JAVA_BIN} ${JAVA_ARGS} ${LOG_APPENDER} \
         -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> \
         clojure.main -m <%= EZBake::Config[:main_namespace] %> \
         --config ${CONFIG} --bootstrap-config ${BOOTSTRAP_CONFIG} \


### PR DESCRIPTION
Without this patch the `puppetserver foreground` subcommand does not work out
of the box on our EL-7 systems.  The command prompts for a password because the
puppet user does not have a valid shell.  There is no known work-around without
invasive modification to the system configuration, e.g. giving puppet a valid
shell or adjusting the PAM configuration.

This patch addresses the problem by switching `su` to `runuser` which is
specifically designed to execute commands in shells as users with otherwise
invalid login shells.
