### PR TITLE
(MAINT) Add a CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+## 0.2.3
+2015-02-19 - Nate Wolfe <nwolfe@puppetlabs.com>
+ * (SERVER-363) Standardize on $rubylibdir (affee8d)
+
+2015-02-19 - Nate Wolfe <nwolfe@puppetlabs.com>
+ * (SERVER-363) Plumb $puppet_libdir into redhat install step (db625ac)
+
+2015-02-19 - Nate Wolfe <nwolfe@puppetlabs.com>
+ * (MAINT) Use project :real_name in FOSS postinstall (71bb30b)
+
+## 0.2.2
+2015-02-13 - Rob Braden <bradejr@puppetlabs.com>
+ * (maint) Update path to install.sh for debian postinst (d1111ee)
+
+2015-02-13 - Rob Braden <bradejr@puppetlabs.com>
+ * (maint) RPM spec puts config files in the wrong place (e8883c3)
+
+2015-02-13 - Rob Braden <bradejr@puppetlabs.com>
+ * (maint) Typo in install.sh (8f2aba8)
+
+2015-02-11 - Rob Braden <bradejr@puppetlabs.com>
+ * (pe-7929) Add ability to create arbitrary dirs (06e01f4)
+
+2015-02-04 - Jeff McCune <jeff@puppetlabs.com>
+ * (SERVER-338) Add net-tools dependency for service unit files (40e3935)
+
+## 0.2.1
+2015-02-05 - Ken Barber <ken@bob.sh>
+ * (PDB-1034) Honor local-repo for aether requests (a534154)


### PR DESCRIPTION
This commit introduces a CHANGELOG file that includes the
changes (commits) for 0.2.1, 0.2.2, and 0.2.3 releases.

<hr/>

I used the following git command to produce all the commits, then I manually removed the CI commits to keep it clean.

```
git log --pretty=format:'%ad - %aN <%aE>%n * %s (%h)%n' --date=short --date-order --no-merges --patience -M -C -C -c
```

<hr/>

Also, feel free to reject this if the consensus is it's not worth the maintenance effort :smiley: @waynr and I thought it might be useful to have, but I don't think the feeling was too strong.
