### PR TITLE
(SERVER-344) Choose best method to become puppet

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
@@ -17,6 +17,6 @@ if [ "$EUID" = "0" ] && command -v runuser &> /dev/null; then
 elif command -v sudo &> /dev/null; then
   sudo -u "${USER}" "$COMMAND"
 else
-  su "${USER}" -s /bin/bash -c "$COMMAND" 
+  su "${USER}" -s /bin/bash -c $COMMAND
 fi
 popd &> /dev/null


### PR DESCRIPTION
Previously, only the su command was used to switch to the puppet user
and launch Puppet server in the foreground. This does not work on some
systems using SELinux. This commit attempts to use the runuser command
instead if it is installed and the user is running as root, otherwise
sudo or su is used.
