### PR TITLE
(pe-8274)(packaging) Update oomkill parameter for systemd

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
@@ -10,7 +10,7 @@ TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
 
 ExecStart=/usr/bin/java $JAVA_ARGS \
-          -XX:OnOutOfMemoryError=kill\ -9\ %p \
+          '-XX:OnOutOfMemoryError=kill -9 %%p' \
           -XX:+HeapDumpOnOutOfMemoryError \
           -XX:HeapDumpPath=/var/log/puppetlabs/<%= EZBake::Config[:project] %> \
           -Djava.security.egd=/dev/urandom \

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
@@ -10,7 +10,7 @@ TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
 
 ExecStart=/opt/puppet/bin/java $JAVA_ARGS \
-          -XX:OnOutOfMemoryError=kill\ -9\ %p \
+          '-XX:OnOutOfMemoryError=kill -9 %%p' \
           -XX:+HeapDumpOnOutOfMemoryError \
           -XX:HeapDumpPath=/var/log/<%= EZBake::Config[:project] %> \
           -Djava.security.egd=/dev/urandom \


### PR DESCRIPTION
Currently, services are unable to oomkill themselves due
to incorrectly passed parameters in the systemd unit file.

This updates the out of memory condition handler in the
systemd unit file to correctly pass the parameters to the shell,
and then to the java process.
