### PR TITLE
(EZ-31) Add pre_start_action to start scripts

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -24,6 +24,7 @@ module EZBake
                           :additional_preinst => [{{{debian-preinst}}}],
                           :additional_postinst => [{{{debian-postinst}}}],
                           :additional_install => [{{{debian-install}}}],
+                          :pre_start_action => [{{{debian-pre-start-action}}}],
                           :post_start_action => [{{{debian-post-start-action}}}],
                           },
       :redhat         => {
@@ -31,6 +32,7 @@ module EZBake
                           :additional_preinst => [{{{redhat-preinst}}}],
                           :additional_postinst => [{{{redhat-postinst}}}],
                           :additional_install => [{{{redhat-install}}}],
+                          :pre_start_action => [{{{redhat-pre-start-action}}}],
                           :post_start_action => [{{{redhat-post-start-action}}}],
                           },
       :main_namespace => '{{{main-namespace}}}',

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -51,6 +51,10 @@ EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemory
 #
 do_start()
 {
+    <% EZBake::Config[:debian][:pre_start_action].each do |action| -%>
+        <%= action %>
+    <% end -%>
+
     start-stop-daemon --start $EXTRA_ARGS --quiet --pidfile $PIDFILE --chdir $INSTALL_DIR --exec $JAVA_BIN \
         --startas /bin/bash -- -c "exec $EXEC >> /var/log/<%= EZBake::Config[:project] %>/<%= EZBake::Config[:project] %>-daemon.log 2>&1"
     retval=$?

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
@@ -9,6 +9,13 @@ User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
 
+<% unless EZBake::Config[:redhat][:pre_start_action].empty? -%>
+PermissionsStartOnly=true
+<% EZBake::Config[:redhat][:pre_start_action].each do |action| -%>
+ExecStartPre=<%= action %>
+<% end -%>
+<% end -%>
+
 ExecStart=/usr/bin/java $JAVA_ARGS \
           '-XX:OnOutOfMemoryError=kill -9 %%p' \
           -XX:+HeapDumpOnOutOfMemoryError \

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -56,6 +56,11 @@ start() {
     [ -e $config ] || exit 6
     # Move any heap dumps aside
     echo -n $"Starting $prog: "
+
+    <% EZBake::Config[:redhat][:pre_start_action].each do |action| -%>
+        <%= action %>
+    <% end -%>
+
     pushd "${INSTALL_DIR}" &> /dev/null
     daemon --user $USER --pidfile $PIDFILE "$EXEC >> /var/log/puppetlabs/<%= EZBake::Config[:project] %>/<%= EZBake::Config[:project] %>-daemon.log 2>&1 &"
     retval=$?

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -53,6 +53,10 @@ EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemory
 #
 do_start()
 {
+    <% EZBake::Config[:debian][:pre_start_action].each do |action| -%>
+        <%= action %>
+    <% end -%>
+
     start-stop-daemon --start $EXTRA_ARGS --quiet --pidfile $PIDFILE --chdir $INSTALL_DIR --exec $JAVA_BIN \
         --startas /bin/bash -- -c "exec $EXEC >> /var/log/<%= EZBake::Config[:project] %>/<%= EZBake::Config[:project] %>-daemon.log 2>&1"
     retval=$?

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
@@ -9,6 +9,13 @@ User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
 
+<% unless EZBake::Config[:redhat][:pre_start_action].empty? -%>
+PermissionsStartOnly=true
+<% EZBake::Config[:redhat][:pre_start_action].each do |action| -%>
+ExecStartPre=<%= action %>
+<% end -%>
+<% end -%>
+
 ExecStart=/opt/puppet/bin/java $JAVA_ARGS \
           '-XX:OnOutOfMemoryError=kill -9 %%p' \
           -XX:+HeapDumpOnOutOfMemoryError \

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -56,6 +56,11 @@ start() {
     [ -e $config ] || exit 6
     # Move any heap dumps aside
     echo -n $"Starting $prog: "
+
+    <% EZBake::Config[:redhat][:pre_start_action].each do |action| -%>
+        <%= action %>
+    <% end -%>
+
     pushd "${INSTALL_DIR}" &> /dev/null
     daemon --user $USER --pidfile $PIDFILE "$EXEC >> /var/log/<%= EZBake::Config[:project] %>/<%= EZBake::Config[:project] %>-daemon.log 2>&1 &"
     retval=$?

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -58,6 +58,11 @@ start() {
     [ -x "${JAVA_BIN}" ] || exit 5
     [ -e "${config}" ] || exit 6
     echo -n $"Starting ${prog}: "
+
+    <% EZBake::Config[:redhat][:pre_start_action].each do |action| -%>
+        <%= action %>
+    <% end -%>
+
     export HOME="$(getent passwd ${USER} | cut -d':' -f6)"
     # startproc will change users, so make sure that user has permission
     # to access the present working directory.

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -387,11 +387,13 @@ Bundled packages: %s
          :debian-preinst            (get-quoted-ezbake-values :debian :preinst)
          :debian-postinst           (get-quoted-ezbake-values :debian :postinst)
          :debian-install            (get-quoted-ezbake-values :debian :install)
+         :debian-pre-start-action   (get-quoted-ezbake-values :debian :pre-start-action)
          :debian-post-start-action  (get-quoted-ezbake-values :debian :post-start-action)
          :redhat-deps               (get-quoted-ezbake-values :redhat :dependencies)
          :redhat-preinst            (get-quoted-ezbake-values :redhat :preinst)
          :redhat-postinst           (get-quoted-ezbake-values :redhat :postinst)
          :redhat-install            (get-quoted-ezbake-values :redhat :install)
+         :redhat-pre-start-action   (get-quoted-ezbake-values :redhat :pre-start-action)
          :redhat-post-start-action  (get-quoted-ezbake-values :redhat :post-start-action)
          :terminus-map              termini
          :replaces-pkgs             (get-local-ezbake-var lein-project :replaces-pkgs [])


### PR DESCRIPTION
In order for the `install` command to work from a Puppet server build I needed to add the `PermissionsStartOnly=true` line which instructs systemd to run the `ExecStartPre` commands as root before switching to the service user
