### PR TITLE
(maint) Move version string to a variable

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,5 @@
+(def lein-ezbake-stable-branch-version "0.2.5-SNAPSHOT")
+
 (defn deploy-info
   [url]
   { :url url
@@ -5,7 +7,7 @@
     :password :env/nexus_jenkins_password
     :sign-releases false })
 
-(defproject puppetlabs/lein-ezbake "0.2.5-SNAPSHOT"
+(defproject puppetlabs/lein-ezbake lein-ezbake-stable-branch-version
   :description "A system for building packages for trapperkeeper-based applications"
   :dependencies [[me.raynes/fs "1.4.6" :exclusions [org.clojure/clojure]]
                  [me.raynes/conch "0.8.0"]


### PR DESCRIPTION
Without this patch there are near-constant conflicts when merging stable
into master.  This is annoying.  This patch addresses the problem by
moving the version identifier to a variable, which will remain constant
and avoid frequent merge conflicts into master.
