### PR TITLE
(QENG-2013) Fix broken manifest generation in ezbake.

### DIFF
--- a/src/puppetlabs/ezbake/dependency_utils.clj
+++ b/src/puppetlabs/ezbake/dependency_utils.clj
@@ -169,7 +169,8 @@
           (:dependencies lein-project)
           (aether/resolve-dependencies
             :coordinates (:dependencies lein-project)
-            :repositories (:repositories lein-project)))
+            :repositories (:repositories lein-project)
+            :local-repo (:local-repo lein-project)))
         (add-dep-hierarchy-to-string! sb 0))
     (.toString sb)))
 


### PR DESCRIPTION
@cprice404 @dankreek @nwolfe @haus 
This fixes a bug introduced by PE-8229 that breaks CI jobs where we use -SNAPSHOT versions of artifacts installed in a `:local-repo`.
