### PR TITLE
(DO NOT MERGE) (RE-3976) Add additional_postinst to Debian template

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/postinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/postinst.erb
@@ -1,3 +1,7 @@
 #!/bin/sh
 
 /opt/puppet/share/<%= EZBake::Config[:real_name] -%>/scripts/install.sh postinst_deb
+
+<% EZBake::Config[:debian][:additional_postinst].each do |cmd| -%>
+    <%= cmd %>
+<% end -%>


### PR DESCRIPTION
This commit updates the PE Debian postinst template to allow
specification of additional postinst commands. This is needed
to allow us to explicitly set update-rc.d priorities to
accomodate Ubuntu LTS platforms that have legacy bootordering
enabled.
