### PR TITLE
(SERVER-508) Use su before sudo

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
@@ -15,7 +15,7 @@ pushd "${INSTALL_DIR}" &> /dev/null
 if [ "$EUID" = "0" ] && command -v runuser &> /dev/null; then
   runuser "${USER}" -s /bin/bash -c "$COMMAND"
 elif command -v su &> /dev/null; then
-  su "${USER}" -s /bin/bash -c "exec $COMMAND"
+  su "${USER}" -s /bin/bash -c "$COMMAND"
 else
   sudo -u "${USER}" $COMMAND
 fi


### PR DESCRIPTION
Without this patch the sudo command is used to start puppetserver when EUID is
0.  This is a problem on Ubuntu 14.04 because the puppet user is not in the
sudoers file and the sudo command simply exits without executing anything.

This patch addresses the problem by trying su before trying sudo.  sudo is used
as a last resort.
