### PR TITLE
(SERVER-508) Use su before sudo

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
@@ -26,9 +26,13 @@ elif [ "$EUID" = "0" ]; then
     sudo -u "${USER}" $COMMAND
   fi
 else
-  echo "ERROR: This shell is not running as root or $USER" >&2
-  echo "Cannot switch over to $USER, please start puppetserver foreground" >&2
-  echo "from a root or $USER shell." >&2
+  echo "ERROR: Cannot start puppetserver from this shell, running as $LOGNAME" 1>&2
+  echo "When running as $LOGNAME puppetserver cannot switch users to $USER" 1>&2
+  echo "To proceed please try again from a shell running as root or $USER" 1>&2
+  echo "" 1>&2
+  echo "For example:" 1>&2
+  echo "    sudo -H -u $USER /opt/puppetlabs/bin/puppetserver foreground" 1>&2
+
   exit 1
 fi
 popd &> /dev/null


### PR DESCRIPTION
Without this patch the sudo command is used to start puppetserver when EUID is
0.  This is a problem on Ubuntu 14.04 because the puppet user is not in the
sudoers file and the sudo command simply exits without executing anything.

This patch addresses the problem by trying su before trying sudo.  sudo is used
as a last resort.
