### PR TITLE
(EZ-34) Allow ezbake to set apt/yum repo_name for packaging

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
@@ -50,6 +50,8 @@ templates:
 tar_excludes:
   - .gitignore
 build_pe: {{{is-pe-build}}}
+apt_repo_name: {{{repo-name}}}
+yum_repo_name: {{{repo-name}}}
 gem_files:
 gem_require_path:
 gem_test_files:

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -423,7 +423,8 @@ Dependency tree:
                               (:description lein-project)
                               (deputils/generate-manifest-string lein-project))
        :uberjar-name  (:uberjar-name lein-project)
-       :is-pe-build   (format "%s" (= (get-local-ezbake-var lein-project :build-type "foss") "pe"))})))
+       :is-pe-build   (format "%s" (= (get-local-ezbake-var lein-project :build-type "foss") "pe"))
+       :repo-name     (format "%s" (get-local-ezbake-var lein-project :repo-target ""))})))
 
 (defmulti action
   (fn [action & args] action))


### PR DESCRIPTION
In order to ship projects such as puppetserver 2.0 to a repo other than
main/products, ezbake needs to be wired up to do so. This commit adds an
ezbake key called repo-target which will set the correct keys in
project_data.yaml to ensure this can happen.
