### PR TITLE
(EZ-39) Update ezbake to use java 8 when available on debian

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/control.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/control.erb
@@ -10,7 +10,7 @@ Package: <%= EZBake::Config[:project] %>
 Architecture: all
 # net-tools is required for netstat usage in service unit file
 # See: https://tickets.puppetlabs.com/browse/SERVER-338
-Depends: ${misc:Depends}, java7-runtime-headless, net-tools, adduser<%=
+Depends: ${misc:Depends}, java7-runtime-headless | java8-runtime-headless, net-tools, adduser<%=
     if !EZBake::Config[:debian][:additional_dependencies].empty?
       ", " + EZBake::Config[:debian][:additional_dependencies].join(", ")
     end %>


### PR DESCRIPTION
Ubuntu's vivid release will include a java 8 package, as will debian's
release after jessie. This commit adds java8-runtime-headless as an
option if java7 is not available.
