### PR TITLE
(maint) Merge stable to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ This release contains bug fixes and AIO path changes.
  * (SERVER-369) Update ezbake to use new AIO directories (2eb3628)
  * (SERVER-387) Update to AIO server confdir layout (ee0a593)
 
+## 0.2.8
+ * Fix copy-paste error in EL init script template
+ * Use templated :start_timeout value in Debian init scripts.
+
+## 0.2.7
+ * Add 'Should-Start' LSB headers to SUSE and EL init script templates
+ * Add Fedora 21 build target
+ * Remove Fedora 19 build target
+
 ## 0.2.6
  * Feature: Add a full lein dependency tree to the ezbake.manifest file that is
    included in packages.

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -29,7 +29,7 @@ DESC="<%= EZBake::Config[:project] %> Puppet Labs version-checking backend"
 JARFILE="<%= EZBake::Config[:uberjar_name] %>"
 PIDFILE=/var/run/puppetlabs/$NAME/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
-START_TIMEOUT=${START_TIMEOUT:-60}
+START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 
 JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b '${BOOTSTRAP_CONFIG}'"
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/rules.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/rules.erb
@@ -16,6 +16,7 @@ export datadir=/opt/puppetlabs/server/data/<%= EZBake::Config[:project] %>
 export localstatedir=/var
 export sharedstatedir=/var/lib
 export realname=<%= EZBake::Config[:real_name] %>
+export EZ_VERBOSE=1
 
 install/<%= EZBake::Config[:project] %>::
 	bash install.sh install_deb

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -110,21 +110,21 @@ Contains terminus for:
 %install
 
 rm -rf $RPM_BUILD_ROOT
-env DESTDIR=%{buildroot} prefix=%{_prefix} app_prefix=%{_app_prefix} app_data=%{_app_data} confdir=%{_sysconfdir} bindir=%{_app_bindir} symbindir=%{_sym_bindir} rundir=%{_app_rundir} localstatedir=%{_localstatedir} rubylibdir=%{rubylibdir} bash install.sh install_redhat
+env EZ_VERBOSE=1 DESTDIR=%{buildroot} prefix=%{_prefix} app_prefix=%{_app_prefix} app_data=%{_app_data} confdir=%{_sysconfdir} bindir=%{_app_bindir} symbindir=%{_sym_bindir} rundir=%{_app_rundir} localstatedir=%{_localstatedir} rubylibdir=%{rubylibdir} bash install.sh install_redhat
 %if %{_with_systemd}
-env DESTDIR=%{buildroot} prefix=%{_prefix} app_prefix=%{_app_prefix} app_data=%{_app_data} confdir=%{_sysconfdir} bindir=%{_app_bindir} symbindir=%{_sym_bindir} rundir=%{_app_rundir} defaultsdir=%{_sysconfdir}/sysconfig unitdir=%{_unitdir} bash install.sh systemd_redhat
+env EZ_VERBOSE=1 DESTDIR=%{buildroot} prefix=%{_prefix} app_prefix=%{_app_prefix} app_data=%{_app_data} confdir=%{_sysconfdir} bindir=%{_app_bindir} symbindir=%{_sym_bindir} rundir=%{_app_rundir} defaultsdir=%{_sysconfdir}/sysconfig unitdir=%{_unitdir} bash install.sh systemd_redhat
 %else
-env DESTDIR=%{buildroot} prefix=%{_prefix} app_prefix=%{_app_prefix} app_data=%{_app_data} confdir=%{_sysconfdir} bindir=%{_app_bindir} symbindir=%{_sym_bindir} rundir=%{_app_rundir} defaultsdir=%{_sysconfdir}/sysconfig initdir=%{_initrddir} bash install.sh sysv_init_redhat
+env EZ_VERBOSE=1 DESTDIR=%{buildroot} prefix=%{_prefix} app_prefix=%{_app_prefix} app_data=%{_app_data} confdir=%{_sysconfdir} bindir=%{_app_bindir} symbindir=%{_sym_bindir} rundir=%{_app_rundir} defaultsdir=%{_sysconfdir}/sysconfig initdir=%{_initrddir} bash install.sh sysv_init_redhat
 %endif
 
 %if 0%{?fedora} >= 16 || 0%{?rhel} >= 7 || 0%{?sles_version} >= 12
-env DESTDIR=%{buildroot} confdir=%{_sysconfdir} bash install.sh logrotate
+env EZ_VERBOSE=1 DESTDIR=%{buildroot} confdir=%{_sysconfdir} bash install.sh logrotate
 %else
-env DESTDIR=%{buildroot} confdir=%{_sysconfdir} bash install.sh logrotate_legacy
+env EZ_VERBOSE=1 DESTDIR=%{buildroot} confdir=%{_sysconfdir} bash install.sh logrotate_legacy
 %endif
 
 <% unless EZBake::Config[:terminus_info].empty? -%>
-env DESTDIR=%{buildroot} rubylibdir=%{rubylibdir} prefix=%{_prefix} bash install.sh termini
+env EZ_VERBOSE=1 DESTDIR=%{buildroot} rubylibdir=%{rubylibdir} prefix=%{_prefix} bash install.sh termini
 <% end -%>
 
 %clean

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
 set -e
-set -x
+
+if [ -n "${EZ_VERBOSE}" ]; then
+    set -x
+fi
 
 # Warning: This variable API is experimental so these variables may be subject
 # to change in the future.
@@ -29,16 +32,18 @@ app_logdir=${app_logdir:=/var/log/puppetlabs/${real_name}}
 # EZBake Vars    #
 ##################
 
-set +x
-echo "#-------------------------------------------------#"
-echo "The following variables are set: "
-echo
-env | sort
+if [ -n "${EZ_VERBOSE}" ]; then
+    set +x
+    echo "#-------------------------------------------------#"
+    echo "The following variables are set: "
+    echo
+    env | sort
 
-echo
-echo "End of variable print."
-echo "#-------------------------------------------------#"
-set -x
+    echo
+    echo "End of variable print."
+    echo "#-------------------------------------------------#"
+    set -x
+fi
 
 ##################
 # Task functions #
@@ -301,16 +306,23 @@ function task_logrotate_legacy {
 # Misc functions #
 ##################
 
+# Print output only if EZ_VERBOSE is set
+function debug_echo {
+    if [ -n "${EZ_VERBOSE}" ]; then
+        echo $@
+    fi
+}
+
 # Do basic OS detection using facter.
 function osdetection {
     OSFAMILY=`facter osfamily`
     MAJREV=`facter operatingsystemmajrelease`
 
-    echo "OS Detection results"
-    echo
-    echo "OSFAMILY: ${OSFAMILY}"
-    echo "MAJREV: ${MAJREV}"
-    echo
+    debug_echo "OS Detection results"
+    debug_echo
+    debug_echo "OSFAMILY: ${OSFAMILY}"
+    debug_echo "MAJREV: ${MAJREV}"
+    debug_echo
 }
 
 # Run a task
@@ -319,7 +331,7 @@ function osdetection {
 function task {
     local task=$1
     shift
-    echo "Running task ${task} ..."
+    debug_echo "Running task ${task} ..."
     eval task_$task $@
 }
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -31,7 +31,7 @@ DESC="<%= EZBake::Config[:project] %> Puppet Labs version-checking backend"
 JARFILE="<%= EZBake::Config[:uberjar_name] %>"
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
-START_TIMEOUT=${START_TIMEOUT:-60}
+START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 
 JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b '${BOOTSTRAP_CONFIG}'"
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/rules.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/rules.erb
@@ -15,6 +15,7 @@ export confdir=/etc/puppetlabs
 export datadir=$(prefix)/share
 export sharedstatedir=/var/lib
 export realname=<%= EZBake::Config[:real_name] %>
+export EZ_VERBOSE=1
 
 install/<%= EZBake::Config[:project] %>::
 	bash install.sh install_deb

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -141,25 +141,25 @@ Contains terminus for:
 
 rm -rf $RPM_BUILD_ROOT
 
-env DESTDIR=%{buildroot} prefix=%{_prefix} confdir=%{_sysconfdir} bindir=%{_bindir} rundir=%{_rundir}/<%= EZBake::Config[:project] %> localstatedir=%{_localstatedir} bash install.sh install_redhat
+env EZ_VERBOSE=1 DESTDIR=%{buildroot} prefix=%{_prefix} confdir=%{_sysconfdir} bindir=%{_bindir} rundir=%{_rundir}/<%= EZBake::Config[:project] %> localstatedir=%{_localstatedir} bash install.sh install_redhat
 %if %{_with_systemd}
-env DESTDIR=%{buildroot} prefix=%{_prefix} confdir=%{_sysconfdir} bindir=%{_bindir} rundir=%{_rundir}/<%= EZBake::Config[:project] %> defaultsdir=%{_real_sysconfdir}/sysconfig unitdir=%{_unitdir} bash install.sh systemd_redhat
+env EZ_VERBOSE=1 DESTDIR=%{buildroot} prefix=%{_prefix} confdir=%{_sysconfdir} bindir=%{_bindir} rundir=%{_rundir}/<%= EZBake::Config[:project] %> defaultsdir=%{_real_sysconfdir}/sysconfig unitdir=%{_unitdir} bash install.sh systemd_redhat
 %else
 %if %{_old_el}
-env DESTDIR=%{buildroot} prefix=%{_prefix} confdir=%{_sysconfdir} bindir=%{_bindir} rundir=%{_rundir}/<%= EZBake::Config[:project] %> defaultsdir=%{_real_sysconfdir}/sysconfig initdir=%{_initrddir} bash install.sh sysv_init_redhat
+env EZ_VERBOSE=1 DESTDIR=%{buildroot} prefix=%{_prefix} confdir=%{_sysconfdir} bindir=%{_bindir} rundir=%{_rundir}/<%= EZBake::Config[:project] %> defaultsdir=%{_real_sysconfdir}/sysconfig initdir=%{_initrddir} bash install.sh sysv_init_redhat
 %elseif %{_old_sles}
-env DESTDIR=%{buildroot} prefix=%{_prefix} confdir=%{_sysconfdir} bindir=%{_bindir} rundir=%{_rundir}/<%= EZBake::Config[:project] %> defaultsdir=%{_real_sysconfdir}/sysconfig initdir=%{_initrddir} bash install.sh sysv_init_suse
+env EZ_VERBOSE=1 DESTDIR=%{buildroot} prefix=%{_prefix} confdir=%{_sysconfdir} bindir=%{_bindir} rundir=%{_rundir}/<%= EZBake::Config[:project] %> defaultsdir=%{_real_sysconfdir}/sysconfig initdir=%{_initrddir} bash install.sh sysv_init_suse
 %endif
 %endif
 
 %if 0%{?fedora} >= 16 || 0%{?rhel} >= 7 || 0%{?sles_version} >= 12
-env DESTDIR=%{buildroot} confdir=%{_real_sysconfdir} bash install.sh logrotate
+env EZ_VERBOSE=1 DESTDIR=%{buildroot} confdir=%{_real_sysconfdir} bash install.sh logrotate
 %else
-env DESTDIR=%{buildroot} confdir=%{_real_sysconfdir} bash install.sh logrotate_legacy
+env EZ_VERBOSE=1 DESTDIR=%{buildroot} confdir=%{_real_sysconfdir} bash install.sh logrotate_legacy
 %endif
 
 <% unless EZBake::Config[:terminus_info].empty? -%>
-env DESTDIR=%{buildroot} rubylibdir=%{rubylibdir} prefix=%{_prefix} bash install.sh termini
+env EZ_VERBOSE=1 DESTDIR=%{buildroot} rubylibdir=%{rubylibdir} prefix=%{_prefix} bash install.sh termini
 <% end -%>
 
 %clean

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -11,6 +11,10 @@
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
+<% if EZBake::Config[:start_after] -%>
+# Should-Start:      <%= EZBake::Config[:start_after].map {|dep| "#{dep}" }.join(" ") %>
+# Should-Stop:       <%= EZBake::Config[:start_after].map {|dep| "#{dep}" }.join(" ") %>
+<% end -%>
 # Short-Description: <%= EZBake::Config[:project] %>
 # Description:       Start <%= EZBake::Config[:project] %> daemon placed in /etc/init.d.
 ### END INIT INFO

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -11,6 +11,10 @@
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
+<% if EZBake::Config[:start_after] -%>
+# Should-Start:      <%= EZBake::Config[:start_after].map {|dep| "#{dep}" }.join(" ") %>
+# Should-Stop:       <%= EZBake::Config[:start_after].map {|dep| "#{dep}" }.join(" ") %>
+<% end -%>
 # Short-Description: <%= EZBake::Config[:project] %>
 # Description:       Start <%= EZBake::Config[:project] %> daemon placed in /etc/init.d.
 ### END INIT INFO


### PR DESCRIPTION
- origin/stable:
  (EZ-38) Update packaging to enable verbose install.sh
  (EZ-38) Update install.sh to default to using an inside voice
  Version 0.2.9-SNAPSHOT
  Version 0.2.8
  (maint) Update changelog for 0.2.8
  (maint) Use templated START_TIMEOUT in Debian init scripts
  (RE-4434) Fix copy-paste error in ezbake RedHat init script tempate
  Version 0.2.8-SNAPSHOT
  Version 0.2.7
  (maint) Update changelog for 0.2.7
  Remove Fedora 19 from build targets
  (RE-3976) Add 'Should-Start' headers to SUSE init script template

Conflicts:
    CHANGELOG.md
    project.clj
    resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
