### PR TITLE
(RE-4396) Do not build stable or testing

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -2,7 +2,7 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 default_cow: 'base-stable-i386.cow'
-cows: 'base-precise-i386.cow base-trusty-i386.cow base-stable-i386.cow base-wheezy-i386.cow base-testing-i386.cow'
+cows: 'base-precise-i386.cow base-trusty-i386.cow base-wheezy-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_key: '4BD6EC30'


### PR DESCRIPTION
We should only be building debian packages for the codenames of the
different available debian platforms. We are currenly building packages
twice for each platform as the moment, since we are building both wheezy
and stable, when we could just be building wheezy. From this logic, we
should not be building packages for oldstable, stable, testing, or
unstable. Since stable and testing are currently the only ones in that
list here, this commit removes them.
