### PR TITLE
(maint) Make default cow precise

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -1,7 +1,7 @@
 ---
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
-default_cow: 'base-stable-i386.cow'
+default_cow: 'base-trusty-i386.cow'
 cows: 'base-precise-i386.cow base-trusty-i386.cow base-wheezy-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'


### PR DESCRIPTION
We don't want to build packages for stable, so we need to ensure the
default cow is not set to stable. This commit updates the default cow to
be precise
