### PR TITLE
(EZ-44) Set sudo HOME for foreground

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
@@ -15,7 +15,7 @@ pushd "${INSTALL_DIR}" &> /dev/null
 if [ "$EUID" = "0" ] && command -v runuser &> /dev/null; then
   runuser "${USER}" -s /bin/bash -c "$COMMAND"
 elif command -v sudo &> /dev/null; then
-  sudo -u "${USER}" $COMMAND
+  sudo -H -u "${USER}" $COMMAND
 else
   su "${USER}" -s /bin/bash -c "$COMMAND"
 fi


### PR DESCRIPTION
This commit changes executions of commands via sudo from the foreground
subcommand to be done with a -H option.  The -H option causes the HOME
environment variable for the process running in sudo to be set to that
of the default home directory for the target user.  The -H overrides the
default behavior on Ubuntu, which is to preserve the HOME variable value
for the user which ran the foreground subcommand.  This change makes
command executions running via sudo consistent with those done for su and
runuser.
