### PR TITLE
(PDB-1455) Correct termini install.sh rubylibdir fallback autodetection

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -172,7 +172,7 @@ function task_termini {
     #
     # This also allows us to prefer PE ruby over system ruby, so this will work
     # with PE as well
-    local rubylibdir=${rubylibdir:=$(/opt/puppet/bin/ruby -rrbconfig -e "puts RbConfig::CONFIG['sitelibdir']" 2>/dev/null || ruby -rrbconfig -e "puts RbConfig::CONFIG['sitelibdir']")}
+    local rubylibdir=${rubylibdir:=$(PATH=/opt/puppetlabs/puppet/bin:/opt/puppet/bin:$PATH ruby -rrbconfig -e "puts RbConfig::CONFIG['sitelibdir']" 2>/dev/null || ruby -rrbconfig -e "puts RbConfig::CONFIG['sitelibdir']")}
 <% EZBake::Config[:terminus_info].each do |proj_name, info| -%>
 <% info[:files].each do |file| -%>
     install -Dm 0644 <%= file -%> "${DESTDIR}${rubylibdir}/<%= file -%>"


### PR DESCRIPTION
The autodetection routine for AIO pathed Puppet rubylibdir wasn't working.
This showed up when we tried to point our PuppetDB source based tests at a
the ezbake upgrade branch.

This patch adds the Puppet 4/AIO path to PATH when trying to call ruby to
figure out where the terminus belongs.

Signed-off-by: Ken Barber ken@bob.sh
