### PR TITLE
(re-4765) vardir should use real_name

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -144,7 +144,7 @@ function task_install {
     install -d -m 0755 "${DESTDIR}${rundir}"
     install -d -m 700 "${DESTDIR}${app_logdir}"
 <% if EZBake::Config[:create_varlib] -%>
-    install -d -m 700 "${DESTDIR}${localstatedir}/lib/<%= EZBake::Config[:project] %>"
+    install -d -m 700 "${DESTDIR}${localstatedir}/lib/<%= EZBake::Config[:real_name] %>"
 <% end -%>
 <% EZBake::Config[:create_dirs].each do |dir| -%>
     install -d -m 700 "${DESTDIR}<%= dir %>"

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -242,7 +242,7 @@ fi
 %defattr(-, root, root)
 %dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_logdir}
 <% if EZBake::Config[:create_varlib] -%>
-%dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_localstatedir}/lib/%{name}
+%dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_localstatedir}/lib/%{realname}
 <% end -%>
 <% if File.exists?("ext/docs") -%>
 %doc ext/docs


### PR DESCRIPTION
Currently, 'vardir' is set to use project_name,
eg /opt/puppetlabs/server/data/puppetdb/lib/pe-puppetdb, which
should be /opt/puppetlabs/server/data/puppetdb/lib/puppetdb - this is
also currently different between RPM and DEB builds, which is
breaking installation of puppetdb on ubuntu.

This changes 'vardir' to use the project 'real_name' instead, and
makes is consistent between RPM and DEB
