### PR TITLE
(PDB-1455) Make permissions to data dir less permissive

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -218,7 +218,7 @@ fi
 <% EZBake::Config[:bin_files].each do |bin_file| -%>
 %{_app_bindir}/<%= bin_file.sub(%r{^ext/bin/}, "") %>
 <% end -%>
-%dir %attr(0775, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_data}
+%dir %attr(0770, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_data}
 %ghost %attr(0755, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_rundir}
 
 

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -279,7 +279,7 @@ function task_postinst_permissions {
     chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> /var/log/puppetlabs/<%= EZBake::Config[:real_name] %>
     chmod 700 /var/log/puppetlabs/<%= EZBake::Config[:real_name] %>
     chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> $app_data
-    chmod 775 $app_data
+    chmod 770 $app_data
 <% if EZBake::Config[:create_varlib] -%>
     chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> ${app_data}/lib/<%= EZBake::Config[:real_name] %>
     chmod 700 ${app_data}/lib/<%= EZBake::Config[:real_name] %>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -265,7 +265,7 @@ fi
 %{_sym_bindir}/<%= bin_file.sub(%r{^ext/bin/}, "") %>
 %{_ux_bindir}/<%= bin_file.sub(%r{^ext/bin/}, "") %>
 <% end -%>
-%dir %attr(0775, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_data}
+%dir %attr(0770, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_data}
 %dir %attr(0755, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_rundir}
 
 <% unless EZBake::Config[:terminus_info].empty? -%>


### PR DESCRIPTION
This patch removes world read-ability to the data directory. For PuppetDB at
least we want to use this directory to replace the old create_varlibdir
functionality instead, but the directory is too permissive for storing HSQLDB
and KahaDB data.

This patch modifies the chmod and permissions of that directory to 770 instead
of 775. It also modifies the Redhat specs to use that permission.

Signed-off-by: Ken Barber ken@bob.sh
