### PR TITLE
(re-4883) Update service account info on upgrade

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/preinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/preinst.erb
@@ -4,19 +4,21 @@
 # source based installation method.
 
 if [ "$1" = install ] || [ "$1" = upgrade ]; then
-    # Create the "<%= EZBake::Config[:user] %>" user
-    if ! getent passwd <%= EZBake::Config[:user] %>  > /dev/null; then
-        adduser --quiet --system --group --home /opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>  \
-            --no-create-home                                 \
-            --gecos "<%= EZBake::Config[:project] %>" \
-            <%= EZBake::Config[:user] %>
-    fi
-
-    # Create the "<%= EZBake::Config[:group] %>" group, if it is missing, and set the
-    # primary group of the "<%= EZBake::Config[:user] %>" user to this group.
-    if ! getent group <%= EZBake::Config[:group] %> > /dev/null; then
-         addgroup --quiet --system <%= EZBake::Config[:group] %>
-         usermod -g <%= EZBake::Config[:group] %> <%= EZBake::Config[:user] %>
+    # Note: changes to this section of the spec may require synchronisation with the
+    # install.sh source based installation methodology.
+    #
+    # Add <%= EZBake::Config[:group] %> group
+    getent group <%= EZBake::Config[:group] %> > /dev/null || \
+      groupadd --system <%= EZBake::Config[:group] %> || :
+    # Add <%= EZBake::Config[:user] %> user
+    if getent passwd <%= EZBake::Config[:user] %> > /dev/null; then
+      usermod --gid <%= EZBake::Config[:group] %> \
+        --home /opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %> \
+        --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
+    else
+      useradd --system --gid <%= EZBake::Config[:group] %> \
+        --home /opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>  --shell /sbin/nologin \
+        --comment "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :
     fi
 
 <% EZBake::Config[:debian][:additional_preinst].each do |cmd| -%>

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -134,11 +134,15 @@ rm -rf $RPM_BUILD_ROOT
 #
 # Add <%= EZBake::Config[:group] %> group
 getent group <%= EZBake::Config[:group] %> > /dev/null || \
-  groupadd -r <%= EZBake::Config[:group] %> || :
+  groupadd --system <%= EZBake::Config[:group] %> || :
 # Add <%= EZBake::Config[:user] %> user
-getent passwd <%= EZBake::Config[:user] %> > /dev/null || \
-  useradd -r -g <%= EZBake::Config[:group] %> -d %{_app_data} -s /sbin/nologin \
-     -c "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :
+if getent passwd <%= EZBake::Config[:user] %> > /dev/null; then
+  usermod --gid <%= EZBake::Config[:group] %> --home %{_app_data} \
+  --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
+else
+  useradd --system --gid <%= EZBake::Config[:group] %> --home %{_app_data} --shell /sbin/nologin \
+    --comment "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :
+fi
 <% EZBake::Config[:redhat][:additional_preinst].each do |cmd| -%>
 <%= cmd %>
 <% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/preinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/preinst.erb
@@ -4,19 +4,21 @@
 # source based installation method.
 
 if [ "$1" = install ] || [ "$1" = upgrade ]; then
-    # Create the "<%= EZBake::Config[:user] %>" user
-    if ! getent passwd <%= EZBake::Config[:user] %>  > /dev/null; then
-        adduser --quiet --system --group --home /opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>  \
-            --no-create-home                                 \
-            --gecos "<%= EZBake::Config[:project] %>" \
-            <%= EZBake::Config[:user] %>
-    fi
-
-    # Create the "<%= EZBake::Config[:group] %>" group, if it is missing, and set the
-    # primary group of the "<%= EZBake::Config[:user] %>" user to this group.
-    if ! getent group <%= EZBake::Config[:group] %> > /dev/null; then
-         addgroup --quiet --system <%= EZBake::Config[:group] %>
-         usermod -g <%= EZBake::Config[:group] %> <%= EZBake::Config[:user] %>
+    # Note: changes to this section of the spec may require synchronisation with the
+    # install.sh source based installation methodology.
+    #
+    # Add <%= EZBake::Config[:group] %> group
+    getent group <%= EZBake::Config[:group] %> > /dev/null || \
+      groupadd --system <%= EZBake::Config[:group] %> || :
+    # Add <%= EZBake::Config[:user] %> user
+    if getent passwd <%= EZBake::Config[:user] %> > /dev/null; then
+      usermod --gid <%= EZBake::Config[:group] %> \
+        --home /opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %> \
+        --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
+    else
+      useradd --system --gid <%= EZBake::Config[:group] %> \
+        --home /opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>  --shell /sbin/nologin \
+        --comment "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :
     fi
 
 <% EZBake::Config[:debian][:additional_preinst].each do |cmd| -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -165,11 +165,15 @@ rm -rf $RPM_BUILD_ROOT
 #
 # Add <%= EZBake::Config[:group] %> group
 getent group <%= EZBake::Config[:group] %> > /dev/null || \
-  groupadd -r <%= EZBake::Config[:group] %> || :
+  groupadd --system <%= EZBake::Config[:group] %> || :
 # Add <%= EZBake::Config[:user] %> user
-getent passwd <%= EZBake::Config[:user] %> > /dev/null || \
-  useradd -r -g <%= EZBake::Config[:group] %> -d %{_app_data} -s /sbin/nologin \
-     -c "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :
+if getent passwd <%= EZBake::Config[:user] %> > /dev/null; then
+  usermod --gid <%= EZBake::Config[:group] %> --home %{_app_data} \
+  --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
+else
+  useradd --system --gid <%= EZBake::Config[:group] %> --home %{_app_data} --shell /sbin/nologin \
+    --comment "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :
+fi
 <% EZBake::Config[:redhat][:additional_preinst].each do |cmd| -%>
 <%= cmd %>
 <% end -%>


### PR DESCRIPTION
Currently, we are creating the user and group if they
do not exist, however in some cases, like the upgrade from
3.8 to 2015.2, some of the information is changing and needs
to be updated in the service account (like home directory)

This adds logic to set the service account's home directory, group
and GECOS information appropriately if the user account already
exists.
