### PR TITLE
(maint) Remove el5 from build list

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -8,7 +8,7 @@ packager: 'puppetlabs'
 gpg_key: '4BD6EC30'
 sign_tar: FALSE
 # a space separated list of mock configs
-final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-el-7-x86_64 pl-fedora-20-i386 pl-fedora-21-i386'
+final_mocks: 'pl-el-6-i386 pl-el-7-x86_64 pl-fedora-20-i386 pl-fedora-21-i386'
 yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: FALSE


### PR DESCRIPTION
EL 5 does not have a sufficient version of java for puppet server or
puppetdb. Because of this, we should not be building or shipping
packages for this platform.
