### PR TITLE
(RE-4779) Restart service on upgrade

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/postinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/postinst.erb
@@ -1,3 +1,15 @@
 #!/bin/sh
 
-exec "/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] -%>/scripts/install.sh" postinst_deb
+/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] -%>/scripts/install.sh postinst_deb
+
+# On upgrade, we should restart the service if it's running
+if [ $1 = 'configure' -a -n $2 ] ; then
+  if [ -x '/etc/init.d/<%= EZBake::Config[:project] %>' ] ; then
+    # Using sysv
+    invoke-rc.d <%= EZBake::Config[:project] %> try-restart || :
+  elif [ -x /bin/systemctl ] ; then
+    # Using systemd
+    systemctl daemon-reload >/dev/null 2>&1 || :
+    systemctl try-restart <%= EZBake::Config[:project] %>.service
+  fi
+fi

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -148,6 +148,7 @@ fi
 <% end -%>
 
 %post
+%{_app_prefix}/scripts/install.sh postinst_redhat
 %if %{_with_systemd}
 # Reload the systemd units if this is an upgrade
 if [ "$1" = "2" ]; then
@@ -167,7 +168,6 @@ elif [ "$1" = "2" ]; then
     fi
 fi
 %endif
-%{_app_prefix}/scripts/install.sh postinst_redhat
 
 %preun
 %if %{_with_systemd}

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/postinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/postinst.erb
@@ -1,3 +1,15 @@
 #!/bin/sh
 
-exec "/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] -%>/scripts/install.sh" postinst_deb
+/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] -%>/scripts/install.sh postinst_deb
+
+# On upgrade, we should restart the service if it's running
+if [ $1 = 'configure' -a -n $2 ] ; then
+  if [ -x '/etc/init.d/<%= EZBake::Config[:project] %>' ] ; then
+    # Using sysv
+    invoke-rc.d <%= EZBake::Config[:project] %> try-restart || :
+  elif [ -x /bin/systemctl ] ; then
+    # Using systemd
+    systemctl daemon-reload >/dev/null 2>&1 || :
+    systemctl try-restart <%= EZBake::Config[:project] %>.service
+  fi
+fi

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -179,6 +179,7 @@ fi
 <% end -%>
 
 %post
+%{_app_prefix}/scripts/install.sh postinst_redhat
 %if %{_with_systemd}
 # Reload the systemd units if this is an upgrade
 if [ "$1" = "2" ]; then
@@ -204,7 +205,6 @@ elif [ "$1" = "2" ]; then
     fi
 fi
 %endif
-%{_app_prefix}/scripts/install.sh postinst_redhat
 
 %preun
 %if %{_systemd_el}


### PR DESCRIPTION
In the postinst script, we have the potential for making changes to the
service on upgrade. Since we're already restarting the service for rpm,
we should be doing the same thing for deb. However, we want to ensure
this happens after any changes in the postinst script happen.
