### PR TITLE
(RE-5033) Remove obsoletes/provides for termini

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -87,10 +87,6 @@ Requires:         <%= dep %>
 Group: Development/Libraries
 Summary: Termini for <%= EZBake::Config[:project] %>
 Requires: puppet-agent
-<% EZBake::Config[:terminus_info].each do |proj_name, info| -%>
-Obsoletes: <%= proj_name -%>-terminus < <%= info[:version].gsub('-', '.') %>
-Provides:  <%= proj_name -%>-terminus >= <%= info[:version].gsub('-', '.') %>
-<% end -%>
 
 %description termini
 Termini for <%= EZBake::Config[:project] %>


### PR DESCRIPTION
Due to an odd issue with PuppetDB, when PuppetDB 2.3.z and PuppetDB
3.0.0 are in the same repository (e.g. PC1) you can not install
PuppetDB 2.3.z because the terminus package is oboleted and therefore
brings in the 3.0.0 version of temini. That means you can't really run
2.3.5. This is bad since the tests for PuppetDB 2.3.z test against the
AIO and Puppet 3.8 and so they need access to PC1.

As a fix, we're creating a new metapackage 'puppetdb-terminus' at
version 3 that wil require puppetdb-termini to allow for easier
transistion and upgrades. That, combined with the removal of
Obsoletes/Provides in the PuppetDB package will allow a user to use a
2.3.z or 3.0.0 release of PuppetDB.

This will also require yanking of the original PuppetDB 3.0.0 packages
and putting in PuppetDB 3.0.1.

Note: No other packages/projects have used the obsoletes/provides items
n the termini section, so this is a noop for other projects using
EZbake.
