### PR TITLE
(PE-11368) Use real_name in logrotate files

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake.logrotate-legacy.conf.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake.logrotate-legacy.conf.erb
@@ -1,4 +1,4 @@
-/var/log/puppetlabs/<%= EZBake::Config[:project] -%>/*.log {
+/var/log/puppetlabs/<%= EZBake::Config[:real_name] -%>/*.log {
     weekly
     missingok
     rotate 12

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake.logrotate.conf.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake.logrotate.conf.erb
@@ -1,4 +1,4 @@
-/var/log/puppetlabs/<%= EZBake::Config[:project] -%>/*.log {
+/var/log/puppetlabs/<%= EZBake::Config[:real_name] -%>/*.log {
     weekly
     missingok
     rotate 12


### PR DESCRIPTION
In the new FS, both pe-puppet-server and puppet-server put their logs in
/var/log/puppetlabs/puppet-server (or console-services or puppetdb).
Previously the logrotate files referenced project in the directory
instead of real name, which would lead to logrotate trying to rotate a
non-existent directory such as /var/log/puppetlabs/pe-puppet-server.
This commit updates the templates to use real_name instead to avoid
this.
