### PR TITLE
(EZ-52) Add custom created directories to the rpm

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -199,6 +199,9 @@ fi
 <% if EZBake::Config[:create_varlib] -%>
 %dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_data}/lib/%{realname}
 <% end -%>
+<%- EZBake::Config[:create_dirs].each do |dir| -%>
+%dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) <%= dir %>
+<%- end -%>
 <% if File.exists?("ext/docs") -%>
 %doc ext/docs
 <% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -248,6 +248,9 @@ fi
 <% if EZBake::Config[:create_varlib] -%>
 %dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_data}/lib/%{realname}
 <% end -%>
+<%- EZBake::Config[:create_dirs].each do |dir| -%>
+%dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) <%= dir %>
+<%- end -%>
 <% if File.exists?("ext/docs") -%>
 %doc ext/docs
 <% end -%>


### PR DESCRIPTION
Previously in ezbake, custom directories would be added to the buildroot
for rpm, but would not be added to the %files section of the rpm, which
means they would not be included in the package generated. This commit
adds %dir declarations for each dir in create_dirs, and assigns it the
same permissions and ownership that the install.sh postinst will.
