### PR TITLE
(EZ-47) Remove Fedora 20 builds

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -8,7 +8,7 @@ packager: 'puppetlabs'
 gpg_key: '4BD6EC30'
 sign_tar: FALSE
 # a space separated list of mock configs
-final_mocks: 'pl-el-6-i386 pl-el-7-x86_64 pl-fedora-20-i386 pl-fedora-21-i386'
+final_mocks: 'pl-el-6-i386 pl-el-7-x86_64 pl-fedora-21-i386'
 yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: FALSE


### PR DESCRIPTION
Feodra 20 went EOL on 2015-06-23. Because of this, we no longer will be
building and shipping packages for fedora 20.
