### PR TITLE
(EZ-56) Add reload to all ezbake service scripts

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -197,4 +197,4 @@ case "$1" in
         ;;
 esac
 
-:
+exit 0

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -144,6 +144,19 @@ do_restart()
     esac
 }
 
+#
+# Function that sends a SIGHUP to the daemon/service
+#
+do_reload() {
+     #
+     # If the daemon can reload its configuration without
+     # restarting (for example, when it is sent a SIGHUP),
+     # then implement that here.
+     #
+     start-stop-daemon --stop --signal HUP --quiet --pidfile $PIDFILE --name $NAME
+     return 0
+}
+
 case "$1" in
     start)
         [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
@@ -169,16 +182,17 @@ case "$1" in
         get_status_q || exit 0
         do_restart
         ;;
-    restart|force-reload)
-        #
-        # If the "reload" option is implemented then remove the
-        # 'force-reload' alias
-        #
+    restart)
         [ "$VERBOSE" != no ] && log_daemon_msg "Restarting $DESC" "$NAME"
         do_restart
         ;;
+    force-reload|reload)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Reloading $DESC" "$NAME"
+        do_reload
+        log_end_msg $?
+        ;;
     *)
-        echo "Usage: $SCRIPTNAME {start|stop|status|condrestart|try-restart|restart|force-reload}" >&2
+        echo "Usage: $SCRIPTNAME {start|stop|status|condrestart|try-restart|restart|force-reload|reload}" >&2
         exit 3
         ;;
 esac

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
@@ -15,7 +15,7 @@ PermissionsStartOnly=true
 ExecStartPre=<%= action %>
 <% end -%>
 <% end -%>
-
+ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/bin/java $JAVA_ARGS \
           '-XX:OnOutOfMemoryError=kill -9 %%p' \
           -Djava.security.egd=/dev/urandom \

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -124,6 +124,13 @@ rh_status_q() {
     rh_status >/dev/null 2>&1
 }
 
+reload() {
+    echo -n $"Reloading $prog: "
+    killproc -p $PIDFILE $prog -HUP
+    RETVAL=$?
+    echo
+    return $RETVAL
+}
 
 case "$1" in
     start)
@@ -141,11 +148,14 @@ case "$1" in
         rh_status_q || exit 0
         restart
         ;;
+    reload)
+        $1
+        ;;
     status)
         rh_status
         ;;
     *)
-        echo $"Usage: $0 {start|stop|restart|condrestart|try-restart|status}"
+        echo $"Usage: $0 {start|stop|restart|condrestart|try-restart|reload|status}"
         exit 2
 esac
 exit $?

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -197,4 +197,4 @@ case "$1" in
         ;;
 esac
 
-:
+exit 0

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -144,6 +144,19 @@ do_restart()
     esac
 }
 
+#
+# Function that sends a SIGHUP to the daemon/service
+#
+do_reload() {
+     #
+     # If the daemon can reload its configuration without
+     # restarting (for example, when it is sent a SIGHUP),
+     # then implement that here.
+     #
+     start-stop-daemon --stop --signal HUP --quiet --pidfile $PIDFILE --name $NAME
+     return 0
+}
+
 case "$1" in
     start)
         [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
@@ -169,16 +182,17 @@ case "$1" in
         get_status_q || exit 0
         do_restart
         ;;
-    restart|force-reload)
-        #
-        # If the "reload" option is implemented then remove the
-        # 'force-reload' alias
-        #
+    restart)
         [ "$VERBOSE" != no ] && log_daemon_msg "Restarting $DESC" "$NAME"
         do_restart
         ;;
+    force-reload|reload)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Reloading $DESC" "$NAME"
+        do_reload
+        log_end_msg $?
+        ;;
     *)
-        echo "Usage: $SCRIPTNAME {start|stop|status|condrestart|try-restart|restart|force-reload}" >&2
+        echo "Usage: $SCRIPTNAME {start|stop|status|condrestart|try-restart|restart|force-reload|reload}" >&2
         exit 3
         ;;
 esac

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
@@ -16,6 +16,7 @@ ExecStartPre=<%= action %>
 <% end -%>
 <% end -%>
 
+ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/opt/puppetlabs/server/bin/java $JAVA_ARGS \
           '-XX:OnOutOfMemoryError=kill -9 %%p' \
           -Djava.security.egd=/dev/urandom \

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -124,6 +124,13 @@ rh_status_q() {
     rh_status >/dev/null 2>&1
 }
 
+reload() {
+    echo -n $"Reloading $prog: "
+    killproc -p $PIDFILE $prog -HUP
+    RETVAL=$?
+    echo
+    return $RETVAL
+}
 
 case "$1" in
     start)
@@ -141,11 +148,14 @@ case "$1" in
         rh_status_q || exit 0
         restart
         ;;
+    reload)
+        $1
+        ;;
     status)
         rh_status
         ;;
     *)
-        echo $"Usage: $0 {start|stop|restart|condrestart|try-restart|status}"
+        echo $"Usage: $0 {start|stop|restart|condrestart|try-restart|reload|status}"
         exit 2
 esac
 exit $?

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -154,6 +154,12 @@ sl_status() {
     rc_status -v
 }
 
+reload() {
+    echo -n $"Reloading ${prog}:"
+    killproc -p "${PIDFILE}" "$prog" -HUP
+    rc_status -v
+}
+
 
 case "$1" in
     start)
@@ -171,11 +177,14 @@ case "$1" in
         sl_status_q || exit 0
         restart
         ;;
+    reload|force-reload)
+        reload
+        ;;
     status)
         sl_status
         ;;
     *)
-        echo $"Usage: ${0} {start|stop|restart|condrestart|try-restart|status}"
+        echo $"Usage: ${0} {start|stop|restart|condrestart|try-restart|reload|force-reload|status}"
         exit 2
 esac
 exit $?


### PR DESCRIPTION
Previously the init scripts for ezbake projects did not include reload
because trapperkeeper did not support reloading applications (TK-202).
As work on that issue is underway, this commit adds reload everywhere
using SIGHUP. Anywhere that had force-reload defined now calls reload
instead of restart.