### PR TITLE
(EZ-57) Attempt to pull ezbake.conf from both project and upstream jars

### DIFF
--- a/src/puppetlabs/ezbake/dependency_utils.clj
+++ b/src/puppetlabs/ezbake/dependency_utils.clj
@@ -130,7 +130,8 @@
         (if-let [project-jar-entry (find-file-in-jar project-jar
                                                      file-path)]
           (.getInputStream project-jar project-jar-entry)))
-      (log/warnf "Unable to find project jar file: '%s'" project-jar-file))))
+      (lein-main/abort
+       (format "Unable to find project jar file: '%s'" project-jar-file)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public

--- a/src/puppetlabs/ezbake/dependency_utils.clj
+++ b/src/puppetlabs/ezbake/dependency_utils.clj
@@ -4,6 +4,7 @@
   (:require [cemerick.pomegranate.aether :as aether]
             [me.raynes.fs :as fs]
             [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [leiningen.core.main :as lein-main]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -116,6 +117,21 @@
         (assoc acc project-name (.getInputStream jar-file jar-entry)))
       acc)))
 
+(defn get-stream-from-project-jar
+  [lein-project file-path]
+  (let [project-jar-file (fs/file (:target-path lein-project)
+                                  (str
+                                   (:name lein-project)
+                                   "-"
+                                   (:version lein-project)
+                                   ".jar"))]
+    (if (fs/exists? project-jar-file)
+      (let [project-jar (JarFile. project-jar-file)]
+        (if-let [project-jar-entry (find-file-in-jar project-jar
+                                                     file-path)]
+          (.getInputStream project-jar project-jar-entry)))
+      (log/warnf "Unable to find project jar file: '%s'" project-jar-file))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
@@ -154,8 +170,16 @@
   specified file, and whose values are InputStreams for reading the contents of
   those files."
   [lein-project file-path]
-  (let [deps (get-relevant-deps lein-project)]
-    (reduce (partial add-stream-from-jar-to-map lein-project file-path) {} deps)))
+  (let [deps (get-relevant-deps lein-project)
+        upstream-jars (reduce (partial add-stream-from-jar-to-map
+                                       lein-project
+                                       file-path)
+                              {}
+                              deps)]
+    (if-let [stream-from-project (get-stream-from-project-jar lein-project
+                                                              file-path)]
+      (assoc upstream-jars (:name lein-project) stream-from-project)
+      upstream-jars)))
 
 (defn generate-manifest-string
   [lein-project]


### PR DESCRIPTION
In previous commits, ezbake would only try to pull an ezbake.conf file
from upstream dependencies of the jar being packaged.  This commit changes
the logic to also pull in an ezbake.conf file that may be embedded in
the immediate project jar.