### PR TITLE
(PE-12468) Increase service start timeout to 300 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.20 - 2015-11-03
+
+  * Increase default service startup timeout to 300 seconds
+    (5 minutes) to avoid intermittent timeouts in testing.
+
 ## 0.3.19 - 2015-10-29
 
   * Updates to allow pulling in an ezbake.conf from 

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -401,7 +401,7 @@ Dependency tree:
          :terminus-map              termini
          :replaces-pkgs             (get-local-ezbake-var lein-project :replaces-pkgs [])
          :start-after               (quoted-list (get-local-ezbake-var lein-project :start-after []))
-         :start-timeout             (get-local-ezbake-var lein-project :start-timeout "180")
+         :start-timeout             (get-local-ezbake-var lein-project :start-timeout "300")
          :main-namespace            (get-local-ezbake-var lein-project
                                                           :main-namespace
                                                           "puppetlabs.trapperkeeper.main")


### PR DESCRIPTION
Currently, in our testing environment we are occasionally
seeing services timeout on startup at boot. This increases
the default startup timeout to 300 seconds (from 180).

There are a few ways to try and resolve this, this is the most expedient to
try to resolve intermittent issues in testing.