### PR TITLE
(maint) startproc doesn't manage logfile permissions

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -68,6 +68,11 @@ start() {
     <%= action %>
     <% end -%>
 
+    # startproc creates logfiles but doesn't set ownership correctly for new
+    # files. Let's always do this in case the file ownership is wrong.
+    touch "${LOGFILE}"
+    chown $USER:$USER "${LOGFILE}"
+
     export HOME="$(getent passwd ${USER} | cut -d':' -f6)"
     # startproc will change users, so make sure that user has permission
     # to access the present working directory.


### PR DESCRIPTION
If a logfile doesn't exist, startproc will create it as root, not the
user the process is starting at. This will touch the logfile if it
doesn't exist and chown it so that processes started with startproc will
be able to log.