### PR TITLE
(RE-6278) Update permissions for "projconfdir".

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -17,6 +17,7 @@
 # https://github.com/puppetlabs/puppet-specifications/blob/af82509/file_paths.md
 %global _app_prefix /opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>
 %global _app_data /opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>
+%global _projconfdir /etc/puppetlabs/<%= EZBake::Config[:real_name] %>
 
 # java 1.8.0 is available starting in fedora 20 and el 6
 %if 0%{?fedora} >= 20 || 0%{?rhel} >= 6
@@ -188,6 +189,7 @@ fi
 %files
 %defattr(-, root, root)
 %dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_logdir}
+%dir %attr(0750, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_projconfdir}
 <%- EZBake::Config[:create_dirs].each do |dir| -%>
 %dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) <%= dir %>
 <%- end -%>

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -275,6 +275,8 @@ function task_postinst_permissions {
     chmod 700 /var/log/puppetlabs/<%= EZBake::Config[:real_name] %>
     chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> $app_data
     chmod 770 $app_data
+    chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> $projconfdir
+    chmod 750 $projconfdir
 <% EZBake::Config[:create_dirs].each do |dir| -%>
     chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> <%= dir %>
     chmod 700 <%= dir %>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -17,6 +17,7 @@
 # https://github.com/puppetlabs/puppet-specifications/blob/af82509/file_paths.md
 %global _app_prefix /opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>
 %global _app_data /opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>
+%global _projconfdir /etc/puppetlabs/<%= EZBake::Config[:real_name] %>
 
 %global rubylibdir        /opt/puppetlabs/puppet/lib/ruby/vendor_ruby
 
@@ -237,6 +238,7 @@ fi
 %files
 %defattr(-, root, root)
 %dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_logdir}
+%dir %attr(0750, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_projconfdir}
 <%- EZBake::Config[:create_dirs].each do |dir| -%>
 %dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) <%= dir %>
 <%- end -%>


### PR DESCRIPTION
Prior to this commit, Ezbake packages install the
'projconfdir' with 'root:root' ownership and
'755' permissions.

We should probably remove read/execute permissions
to this directory for the 'other/world' group, but
preserve the same permissions for project service
accounts.

This commit updates Ezbake to (1) install the
'projconfdir' with '750' permissions and (2) set
user/group ownership to a project's specific
user and group.