### PR TITLE
(EZ-59) Pass mirrors setting to aether

### DIFF
--- a/src/puppetlabs/ezbake/dependency_utils.clj
+++ b/src/puppetlabs/ezbake/dependency_utils.clj
@@ -4,7 +4,6 @@
   (:require [cemerick.pomegranate.aether :as aether]
             [me.raynes.fs :as fs]
             [clojure.string :as str]
-            [clojure.tools.logging :as log]
             [leiningen.core.main :as lein-main]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -34,7 +33,8 @@
   (-> (aether/resolve-artifacts
         :coordinates [coords]
         :repositories (:repositories lein-project)
-        :local-repo (:local-repo lein-project))
+        :local-repo (:local-repo lein-project)
+        :mirrors (:mirrors lein-project))
       first
       meta
       :file
@@ -195,7 +195,8 @@
           (aether/resolve-dependencies
             :coordinates (:dependencies lein-project)
             :repositories (:repositories lein-project)
-            :local-repo (:local-repo lein-project)))
+            :local-repo (:local-repo lein-project)
+            :mirrors (:mirrors lein-project)))
         (add-dep-hierarchy-to-string! sb 0))
     (.toString sb)))
 


### PR DESCRIPTION
This commit improves the places where ezbake calls into
pomegranate/aether to make sure that we are passing through
the value for the `mirrors` setting from the project (or
from the user profile), so that aether will look for artifacts
in our nexus repository before going out to clojars or
maven central.  This should improve performance and reduce
network I/O for our CI jobs, and help prevent inflating
our clojars download counts from CI jobs.

This change seems like an improvement and step forward regardless
of the version of leiningen that is being used, but until
technomancy/leiningen#2089 is resolved, there may still be
portions of our CI jobs that incorrectly ignore `:local-repo` /
`:mirrors` settings from the user profile.