### PR TITLE
(EZ-61) add restart=on-failure

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
@@ -8,6 +8,8 @@ EnvironmentFile=/etc/sysconfig/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
+Restart=on-failure
+StartLimitBurst=5
 
 <% unless EZBake::Config[:redhat][:pre_start_action].empty? -%>
 PermissionsStartOnly=true

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
@@ -8,6 +8,8 @@ EnvironmentFile=/etc/sysconfig/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
+Restart=on-failure
+StartLimitBurst=5
 
 <% unless EZBake::Config[:redhat][:pre_start_action].empty? -%>
 PermissionsStartOnly=true


### PR DESCRIPTION
To remedy some reoccuring issues with services needing a restart
this comit will add restart=on-failure and startlimitburst=5
to the service file for rpms. refer to further discussion at
https://tickets.puppetlabs.com/browse/RE-5962

Note that on-failure has been available in systemd since v12 [https://github.com/systemd/systemd/releases/tag/v12, systemd/systemd@50caaed]
and is supported on all the systemd platforms we support