### PR TITLE
(EZ-76) Add sleep to wait_for_app

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake-functions.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake-functions.sh.erb
@@ -23,6 +23,7 @@ wait_for_app()
         # if there are any TCP ports associated with the process, return success
         netstat -tulpn 2>/dev/null | grep "$pid" 2>&1 >/dev/null
         if [ "$?" = 0 ]; then
+            sleep 5
             return 0
         fi
 


### PR DESCRIPTION
Ports sometimes are open before the app is really ready to accept
connections. Adding a 5s sleep after we detect the port is open to avoid
race conditions.