### PR TITLE
(maint) Do not use virtual package for java dep

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/control.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/control.erb
@@ -10,7 +10,7 @@ Package: <%= EZBake::Config[:project] %>
 Architecture: all
 # net-tools is required for netstat usage in service unit file
 # See: https://tickets.puppetlabs.com/browse/SERVER-338
-Depends: ${misc:Depends}, java7-runtime-headless | java8-runtime-headless, net-tools, adduser<%=
+Depends: ${misc:Depends}, openjdk-7-jre-headless | openjdk-8-jre-headless, net-tools, adduser<%=
     if !EZBake::Config[:debian][:additional_dependencies].empty?
       ", " + EZBake::Config[:debian][:additional_dependencies].join(", ")
     end %>


### PR DESCRIPTION
Prior to this commit, we were requiring virtual packages to satisfy java
runtime dependencies on deb based platforms. This was fine until we get
to Ubuntu 16.04 Xenial. On Xenial, Java7, Java8, and Java9 all provide
java8-runtime-headless. This is a problem, because it means that java9
is automatically installed to satisfy the specified runtime requirement
of java8-runtime-headless. We're not ready to update puppetserver with
Java9 support yet.

This commit switches from the virtual packages to the actual java
package that we want installed.