### PR TITLE
(maint) add the Ubuntu 16.10 (Xenial) cow to pe build defaults

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
@@ -2,7 +2,7 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 default_cow: 'base-trusty-amd64.cow'
-cows: 'base-precise-amd64.cow base-trusty-amd64.cow'
+cows: 'base-precise-amd64.cow base-trusty-amd64.cow base-xenial-amd64.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppet'
 gpg_key: '4BD6EC30'


### PR DESCRIPTION
This will be required to build for 16.10 in ezbake projects