### PR TITLE
(SERVER-1247) fix bug with services-d bootstrap on systemd

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
@@ -16,7 +16,7 @@ CONFIG="/etc/puppetlabs/<%= EZBake::Config[:real_name] %>/conf.d"
 
 # Bootstrap path
 <% if EZBake::Config[:bootstrap_source] == 'services-d' -%>
-BOOTSTRAP_CONFIG="/etc/puppetlabs/<%= EZBake::Config[:real_name] %>/services.d/,${INSTALL_DIR}/config/services.d/"
+BOOTSTRAP_CONFIG="/etc/puppetlabs/<%= EZBake::Config[:real_name] %>/services.d/,/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/config/services.d/"
 <% else -%>
 BOOTSTRAP_CONFIG="/etc/puppetlabs/<%= EZBake::Config[:real_name] %>/bootstrap.cfg"
 <% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/default.erb
@@ -16,7 +16,7 @@ CONFIG="/etc/puppetlabs/<%= EZBake::Config[:real_name] %>/conf.d"
 
 # Bootstrap path
 <% if EZBake::Config[:bootstrap_source] == 'services-d' -%>
-BOOTSTRAP_CONFIG="/etc/puppetlabs/<%= EZBake::Config[:real_name] %>/services.d/,${INSTALL_DIR}/config/services.d/"
+BOOTSTRAP_CONFIG="/etc/puppetlabs/<%= EZBake::Config[:real_name] %>/services.d/,/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/config/services.d/"
 <% else -%>
 BOOTSTRAP_CONFIG="/etc/puppetlabs/<%= EZBake::Config[:real_name] %>/bootstrap.cfg"
 <% end -%>


### PR DESCRIPTION
In systemd, it doesn't appear that variable interpolation is supported
inside of the defaults files.  Prior to this commit, when using
the `services-d` option for bootstrap configuration, we were generating
a defaults file that relied on interpolation.  This commit changes
the code to avoid the interpolation.