### PR TITLE
(SERVER-1304) Backport removal of heap dump to stable branch

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
@@ -18,8 +18,6 @@ ExecStartPre=<%= action %>
 
 ExecStart=/usr/bin/java $JAVA_ARGS \
           '-XX:OnOutOfMemoryError=kill -9 %%p' \
-          -XX:+HeapDumpOnOutOfMemoryError \
-          -XX:HeapDumpPath=/var/log/<%= EZBake::Config[:project] %> \
           -Djava.security.egd=/dev/urandom \
           -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" clojure.main \
           -m <%= EZBake::Config[:main_namespace] %> \

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -37,7 +37,7 @@ JARFILE="<%= EZBake::Config[:uberjar_name] %>"
 JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b '${BOOTSTRAP_CONFIG}'"
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile=/var/lock/subsys/$prog
-EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/$prog -Djava.security.egd=/dev/urandom $JAVA_ARGS"
+EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -Djava.security.egd=/dev/urandom $JAVA_ARGS"
 PIDFILE="/var/run/$prog/$prog"
 START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -35,7 +35,7 @@ START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 
 JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b '${BOOTSTRAP_CONFIG}'"
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
-EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/$NAME -Djava.security.egd=/dev/urandom $JAVA_ARGS"
+EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -Djava.security.egd=/dev/urandom $JAVA_ARGS"
 
 # Exit if the package is not installed
 [ -x "$JAVA_BIN" ] || exit 0

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
@@ -18,8 +18,6 @@ ExecStartPre=<%= action %>
 
 ExecStart=/opt/puppet/bin/java $JAVA_ARGS \
           '-XX:OnOutOfMemoryError=kill -9 %%p' \
-          -XX:+HeapDumpOnOutOfMemoryError \
-          -XX:HeapDumpPath=/var/log/<%= EZBake::Config[:project] %> \
           -Djava.security.egd=/dev/urandom \
           -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" clojure.main \
           -m <%= EZBake::Config[:main_namespace] %> \

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -41,7 +41,7 @@ JARFILE="<%= EZBake::Config[:uberjar_name] %>"
 JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b '${BOOTSTRAP_CONFIG}'"
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile=/var/lock/subsys/$prog
-EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/$prog -Djava.security.egd=/dev/urandom $JAVA_ARGS"
+EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -Djava.security.egd=/dev/urandom $JAVA_ARGS"
 PIDFILE="/var/run/$prog/$prog"
 START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -71,7 +71,7 @@ start() {
     # startproc will change users, so make sure that user has permission
     # to access the present working directory.
     cd "${INSTALL_DIR}"
-    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}" -Djava.security.egd=/dev/urandom ${JAVA_ARGS}
+    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -Djava.security.egd=/dev/urandom ${JAVA_ARGS}
     rc_status -v
     retval=$?
 
@@ -123,7 +123,7 @@ stop() {
         print_service_pid > "${PIDFILE}"
     fi
 
-    killproc -p "${PIDFILE}" -t"${SERVICE_STOP_RETRIES}"s -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}" "${JAVA_ARGS}"
+    killproc -p "${PIDFILE}" -t"${SERVICE_STOP_RETRIES}"s -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" "${JAVA_ARGS}"
     rc_status -v
     retval=$?
 
@@ -149,7 +149,7 @@ sl_status_q() {
 }
 
 sl_status() {
-    checkproc -p "${PIDFILE}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/${prog}" "${JAVA_ARGS}"
+    checkproc -p "${PIDFILE}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\"" "${JAVA_ARGS}"
     rc_status -v
 }
 


### PR DESCRIPTION
This commit backports the removal of the "HeapDumpOnOutOfMemoryError"
changes to the stable branch, so that we can include them if we
end up doing one more Puppet Server 1.x release.

(The original commit in the master branch is [here](https://github.com/puppetlabs/ezbake/commit/4d906dbe264cd32766d0c48d33aa8154afbb32df) ; it wouldn't cherry-pick cleanly so I did it by hand.)