### PR TITLE
(EZ-83) Update init scripts to set a UMASK of 027

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -15,6 +15,8 @@
 
 # Copyright 2014 Puppet Labs
 
+#set default privileges to -rw-r-----
+umask 027
 
 # You should only need to edit the default/<%= EZBake::Config[:project] %> file and not
 #   this init script directly

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
@@ -10,6 +10,8 @@ TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
 Restart=on-failure
 StartLimitBurst=5
+#set default privileges to -rw-r-----
+UMask=027
 
 <% unless EZBake::Config[:debian][:pre_start_action].empty? -%>
 PermissionsStartOnly=true

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
@@ -10,6 +10,8 @@ TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
 Restart=on-failure
 StartLimitBurst=5
+#set default privileges to -rw-r-----
+UMask=027
 
 <% unless EZBake::Config[:redhat][:pre_start_action].empty? -%>
 PermissionsStartOnly=true

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -24,6 +24,9 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
+#set default privileges to -rw-r-----
+umask 027
+
 prog="<%= EZBake::Config[:project] %>"
 realname="<%= EZBake::Config[:real_name] %>"
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -15,6 +15,8 @@
 
 # Copyright 2014 Puppet Labs
 
+#set default privileges to -rw-r-----
+umask 027
 
 # You should only need to edit the default/<%= EZBake::Config[:project] %> file and not
 #   this init script directly

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
@@ -10,6 +10,8 @@ TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
 Restart=on-failure
 StartLimitBurst=5
+#set default privileges to -rw-r-----
+UMask=027
 
 <% unless EZBake::Config[:debian][:pre_start_action].empty? -%>
 PermissionsStartOnly=true

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
@@ -10,6 +10,8 @@ TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
 Restart=on-failure
 StartLimitBurst=5
+#set default privileges to -rw-r-----
+UMask=027
 
 <% unless EZBake::Config[:redhat][:pre_start_action].empty? -%>
 PermissionsStartOnly=true

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -24,6 +24,9 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
+#set default privileges to -rw-r-----
+umask 027
+
 prog="<%= EZBake::Config[:project] %>"
 realname="<%= EZBake::Config[:real_name] %>"
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -24,6 +24,9 @@
 # Source function library.
 [ -e /lib/lsb/init-functions ] && . /lib/lsb/init-functions
 
+#set default privileges to -rw-r-----
+umask 027
+
 prog="<%= EZBake::Config[:project] %>"
 realname="<%= EZBake::Config[:real_name] %>"
 


### PR DESCRIPTION
Set the default privileges to rw-r----- (permissions 640) so files are not world readable, even if moved out of the properly permissioned parent directories.