### PR TITLE
(EZ-86) Add configuration of open file limit to services

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -5,6 +5,7 @@ module EZBake
       :user           => '{{{user}}}',
       :group          => '{{{group}}}',
       :start_timeout  => '{{{start-timeout}}}',
+      :open_file_limit => '{{{open-file-limit}}}',
       :uberjar_name   => '{{{uberjar-name}}}',
       :config_files   => [{{{config-files}}}],
       :system_config_files   => [{{{system-config-files}}}],

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -58,6 +58,10 @@ EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -Djava.security.egd=/dev/u
 #
 do_start()
 {
+    <% if EZBake::Config[:open_file_limit] -%>
+    [ -n "$OPEN_FILE_LIMIT" ] && ulimit -n $OPEN_FILE_LIMIT
+    <% end -%>
+
     <% EZBake::Config[:debian][:pre_start_action].each do |action| -%>
     <%= action %>
     <% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
@@ -12,6 +12,9 @@ Restart=on-failure
 StartLimitBurst=5
 #set default privileges to -rw-r-----
 UMask=027
+<% if EZBake::Config[:open_file_limit] -%>
+LimitNOFILE=<%= EZBake::Config[:open_file_limit] %>
+<% end -%>
 
 <% unless EZBake::Config[:debian][:pre_start_action].empty? -%>
 PermissionsStartOnly=true

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
@@ -27,3 +27,11 @@ SERVICE_STOP_RETRIES=60
 # seconds.  This is used in System-V style init scripts only, and will have no
 # effect in systemd.
 # START_TIMEOUT=<%= EZBake::Config[:start_timeout] %>
+
+
+<% if EZBake::Config[:open_file_limit] -%>
+# OPEN_FILE_LIMIT can be set here to alter the number of open file descriptors
+# allowed by the service. This is used in System-V style init scripts only, and
+# will have no effect in systemd.
+OPEN_FILE_LIMIT=<%= EZBake::Config[:open_file_limit] %>
+<% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
@@ -12,6 +12,9 @@ Restart=on-failure
 StartLimitBurst=5
 #set default privileges to -rw-r-----
 UMask=027
+<% if EZBake::Config[:open_file_limit] -%>
+LimitNOFILE=<%= EZBake::Config[:open_file_limit] %>
+<% end -%>
 
 <% unless EZBake::Config[:redhat][:pre_start_action].empty? -%>
 PermissionsStartOnly=true

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -66,6 +66,10 @@ start() {
     # Move any heap dumps aside
     echo -n $"Starting $prog: "
 
+    <% if EZBake::Config[:open_file_limit] -%>
+    [ -n "$OPEN_FILE_LIMIT" ] && ulimit -n $OPEN_FILE_LIMIT
+    <% end -%>
+
     <% EZBake::Config[:redhat][:pre_start_action].each do |action| -%>
     <%= action %>
     <% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -58,6 +58,10 @@ EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -Djava.security.egd=/dev/u
 #
 do_start()
 {
+    <% if EZBake::Config[:open_file_limit] -%>
+    [ -n "$OPEN_FILE_LIMIT" ] && ulimit -n $OPEN_FILE_LIMIT
+    <% end -%>
+
     <% EZBake::Config[:debian][:pre_start_action].each do |action| -%>
     <%= action %>
     <% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
@@ -12,6 +12,9 @@ Restart=on-failure
 StartLimitBurst=5
 #set default privileges to -rw-r-----
 UMask=027
+<% if EZBake::Config[:open_file_limit] -%>
+LimitNOFILE=<%= EZBake::Config[:open_file_limit] %>
+<% end -%>
 
 <% unless EZBake::Config[:debian][:pre_start_action].empty? -%>
 PermissionsStartOnly=true

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/default.erb
@@ -27,3 +27,10 @@ SERVICE_STOP_RETRIES=60
 # seconds.  This is used in System-V style init scripts only, and will have no
 # effect in systemd.
 # START_TIMEOUT=<%= EZBake::Config[:start_timeout] %>
+
+<% if EZBake::Config[:open_file_limit] -%>
+# OPEN_FILE_LIMIT can be set here to alter the number of open file descriptors
+# allowed by the service. This is used in System-V style init scripts only, and
+# will have no effect in systemd.
+OPEN_FILE_LIMIT=<%= EZBake::Config[:open_file_limit] %>
+<% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
@@ -12,6 +12,9 @@ Restart=on-failure
 StartLimitBurst=5
 #set default privileges to -rw-r-----
 UMask=027
+<% if EZBake::Config[:open_file_limit] -%>
+LimitNOFILE=<%= EZBake::Config[:open_file_limit] %>
+<% end -%>
 
 <% unless EZBake::Config[:redhat][:pre_start_action].empty? -%>
 PermissionsStartOnly=true

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -66,6 +66,10 @@ start() {
     # Move any heap dumps aside
     echo -n $"Starting $prog: "
 
+    <% if EZBake::Config[:open_file_limit] -%>
+    [ -n "$OPEN_FILE_LIMIT" ] && ulimit -n $OPEN_FILE_LIMIT
+    <% end -%>
+
     <% EZBake::Config[:redhat][:pre_start_action].each do |action| -%>
     <%= action %>
     <% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -67,6 +67,10 @@ start() {
     [ -e "${config}" ] || exit 6
     echo -n $"Starting ${prog}: "
 
+    <% if EZBake::Config[:open_file_limit] -%>
+    [ -n "$OPEN_FILE_LIMIT" ] && ulimit -n $OPEN_FILE_LIMIT
+    <% end -%>
+
     <% EZBake::Config[:redhat][:pre_start_action].each do |action| -%>
     <%= action %>
     <% end -%>

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -423,6 +423,7 @@ Dependency tree:
      :replaces-pkgs             (get-local-ezbake-var lein-project :replaces-pkgs [])
      :start-after               (quoted-list (get-local-ezbake-var lein-project :start-after []))
      :start-timeout             (get-local-ezbake-var lein-project :start-timeout "300")
+     :open-file-limit           (get-local-ezbake-var lein-project :open-file-limit nil)
      :main-namespace            (get-local-ezbake-var lein-project
                                                       :main-namespace
                                                       "puppetlabs.trapperkeeper.main")


### PR DESCRIPTION
Allows ezbake projects to configure a default open file limit as part of
service startup.