### PR TITLE
(EZ-84) Don't create empty pidfile if there's no pid

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -55,7 +55,7 @@ find_my_pid() {
         mkdir -p /var/run/puppetlabs/${realname}
         chown -R $USER:$GROUP /var/run/puppetlabs/${realname}
     fi
-    echo $pid > $PIDFILE
+    [ -n "$pid" ] && echo $pid > $PIDFILE
 }
 
 start() {

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -55,7 +55,7 @@ find_my_pid() {
         mkdir -p /var/run/puppetlabs/${realname}
         chown -R $USER:$GROUP /var/run/puppetlabs/${realname}
     fi
-    echo $pid > $PIDFILE
+    [ -n "$pid" ] && echo $pid > $PIDFILE
 }
 
 start() {


### PR DESCRIPTION
Prior to this commit, the EL init script's "find_my_pid" function
creates an empty pidfile if the service is not running.

This commit updates the "find_my_pid" function to check that $pid is not
a zero-length string before writing a pidfile.