### PR TITLE
(MAINT) fix LimitNOFILE parse error

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -5,7 +5,7 @@ module EZBake
       :user           => '{{{user}}}',
       :group          => '{{{group}}}',
       :start_timeout  => '{{{start-timeout}}}',
-      :open_file_limit => '{{{open-file-limit}}}',
+      :open_file_limit => {{{open-file-limit}}},
       :uberjar_name   => '{{{uberjar-name}}}',
       :config_files   => [{{{config-files}}}],
       :system_config_files   => [{{{system-config-files}}}],

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -423,7 +423,7 @@ Dependency tree:
      :replaces-pkgs             (get-local-ezbake-var lein-project :replaces-pkgs [])
      :start-after               (quoted-list (get-local-ezbake-var lein-project :start-after []))
      :start-timeout             (get-local-ezbake-var lein-project :start-timeout "300")
-     :open-file-limit           (get-local-ezbake-var lein-project :open-file-limit nil)
+     :open-file-limit           (get-local-ezbake-var lein-project :open-file-limit "nil")
      :main-namespace            (get-local-ezbake-var lein-project
                                                       :main-namespace
                                                       "puppetlabs.trapperkeeper.main")


### PR DESCRIPTION
This PR fixes a parse error that was cause by `open_file_limit` being wrapped in quotes. This caused it to always be set which caused parse errors on systemd. This was fixed by removing the quotes in the mustache template and explicitly defining `nil` as a string rather than a nil value in core.clj. This allowed it to become nil once the mustache template is evaluated.