### PR TITLE
(DO NOT MERGE) (EZ-90) add `start` subcommand for ezbake apps

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -6,7 +6,7 @@ initial=$cur
 timeout="300"
 
 if [ -e $restartfile ];  then
-    /usr/bin/java $JAVA_ARGS -Djava.security.egd=/dev/urandom -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> clojure.main -m <%= EZBake::Config[:main_namespace] %> --config "${CONFIG}" -b "${BOOTSTRAP_CONFIG}" &
+    ${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=/dev/urandom -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> clojure.main -m <%= EZBake::Config[:main_namespace] %> --config "${CONFIG}" -b "${BOOTSTRAP_CONFIG}" &
     while [ "$cur" == "$initial" ] ;do
         sleep 0.1
         cur=$(head -n 1 $restartfile)

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+restartfile=/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/restartcounter.txt
+cur=$(head -1 $restartfile)
+initial=$cur
+timeout="300"
+source /etc/sysconfig/puppetserver
+
+if [ -e $restartfile ];  then
+    /usr/bin/java $JAVA_ARGS -Djava.security.egd=/dev/urandom -cp "${INSTALL_DIR}/puppet-server-release.jar" clojure.main -m puppetlabs.trapperkeeper.main --config "${CONFIG}" -b "${BOOTSTRAP_CONFIG}" &
+    while [ "$cur" == "$initial" ] ;do
+        sleep 0.1
+        cur=$(head -1 $restartfile)
+
+        ((timeout--))
+        if [ "$timeout" = 0 ]; then
+            echo "Startup timed out"
+            exit 1
+        fi
+    done
+else
+    echo "Restart file does not exist"
+    exit 1
+fi
+
+exit 0

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
 
 restartfile=/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/restartcounter.txt
-cur=$(head -1 $restartfile)
+cur=$(head -n 1 $restartfile)
 initial=$cur
 timeout="300"
-source /etc/sysconfig/puppetserver
 
 if [ -e $restartfile ];  then
-    /usr/bin/java $JAVA_ARGS -Djava.security.egd=/dev/urandom -cp "${INSTALL_DIR}/puppet-server-release.jar" clojure.main -m puppetlabs.trapperkeeper.main --config "${CONFIG}" -b "${BOOTSTRAP_CONFIG}" &
+    /usr/bin/java $JAVA_ARGS -Djava.security.egd=/dev/urandom -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> clojure.main -m <%= EZBake::Config[:main_namespace] %> --config "${CONFIG}" -b "${BOOTSTRAP_CONFIG}" &
     while [ "$cur" == "$initial" ] ;do
         sleep 0.1
-        cur=$(head -1 $restartfile)
+        cur=$(head -n 1 $restartfile)
 
         ((timeout--))
         if [ "$timeout" = 0 ]; then


### PR DESCRIPTION
NOTE: see conversation about branching considerations on #323 .

-------


This adds a `start` subcommand that will launch the java process asynchronously as a daemon and check for an increment of the counter in the restart file. Once the counter has been incremented, we can then know that the service has successfully started. 