### PR TITLE
(RE-7420) Build FOSS ezbake projects on sles

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -8,7 +8,7 @@ packager: 'puppetlabs'
 gpg_key: '4BD6EC30'
 sign_tar: FALSE
 # a space separated list of mock configs
-final_mocks: 'pl-el-6-i386 pl-el-7-x86_64'
+final_mocks: 'pl-el-6-i386 pl-el-7-x86_64 pl-sles-11-x86_64 pl-sles-12-x86_64'
 yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: FALSE


### PR DESCRIPTION
This unfortunately will not work for builds outside of the puppetlabs
ecosystem. There are no publicly available sles mirrors available, so we
have created our own in house mirror. This is not available to the
public. The sles mocks created with the rpmbuilder module are configured
to hit this internal repo, but to not fail if the user doesn't have
access to it.