### PR TITLE
(EZ-68) fix typo `EZbake` to `EZBake`

### DIFF
--- a/README_BRANCHING.md
+++ b/README_BRANCHING.md
@@ -1,5 +1,5 @@
 This document attempts to capture the details of our branching strategy
-for EZbake.
+for EZBake.
 
 ## NOTE: EZBake is now a lein plugin!
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
@@ -14,7 +14,7 @@ if [ -r "$restartfile" ];  then
 
         ((timeout--))
         if [ "$timeout" = 0 ]; then
-            echo "Reload timed out after <%= EZBake::Config[:start_timeout] / 10 %> seconds"
+            echo "Reload timed out after <%= EZBake::Config[:start_timeout].to_i / 10 %> seconds"
             exit 1
         fi
     done

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -26,7 +26,7 @@ while [ "$cur" == "$initial" ] ;do
 
     ((timeout--))
     if [ "$timeout" = 0 ]; then
-        echo "Startup timed out after <%= EZbake::Config[:start_timeout] %> seconds"
+        echo "Startup timed out after <%= EZBake::Config[:start_timeout] %> seconds"
         exit 1
     fi
 done


### PR DESCRIPTION
This is a fixup PR, changes two typos in EZBake.