### PR TITLE
(EZ-69) Add support for service reload by calling new "reload" subcommand 

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -127,7 +127,6 @@ get_status_q()
     get_status >/dev/null 2>&1
 }
 
-
 #
 # Function that restarts the daemon/service
 #
@@ -154,13 +153,8 @@ do_restart()
 # Function that sends a SIGHUP to the daemon/service
 #
 do_reload() {
-     #
-     # If the daemon can reload its configuration without
-     # restarting (for example, when it is sent a SIGHUP),
-     # then implement that here.
-     #
-     start-stop-daemon --stop --signal HUP --quiet --pidfile $PIDFILE --name $NAME
-     return 0
+    /opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME} reload
+    echo $?
 }
 
 case "$1" in

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -150,6 +150,19 @@ do_restart()
     esac
 }
 
+#
+# Function that sends a SIGHUP to the daemon/service
+#
+do_reload() {
+     #
+     # If the daemon can reload its configuration without
+     # restarting (for example, when it is sent a SIGHUP),
+     # then implement that here.
+     #
+     start-stop-daemon --stop --signal HUP --quiet --pidfile $PIDFILE --name $NAME
+     return 0
+}
+
 case "$1" in
     start)
         [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
@@ -175,16 +188,17 @@ case "$1" in
         get_status_q || exit 0
         do_restart
         ;;
-    restart|force-reload)
-        #
-        # If the "reload" option is implemented then remove the
-        # 'force-reload' alias
-        #
+    restart)
         [ "$VERBOSE" != no ] && log_daemon_msg "Restarting $DESC" "$NAME"
         do_restart
         ;;
+    force-reload|reload)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Reloading $DESC" "$NAME"
+        do_reload
+        log_end_msg $?
+        ;;
     *)
-        echo "Usage: $SCRIPTNAME {start|stop|status|condrestart|try-restart|restart|force-reload}" >&2
+        echo "Usage: $SCRIPTNAME {start|stop|status|condrestart|try-restart|restart|force-reload|reload}" >&2
         exit 3
         ;;
 esac

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -203,4 +203,4 @@ case "$1" in
         ;;
 esac
 
-:
+exit 0

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
@@ -23,6 +23,7 @@ ExecStartPre=<%= action %>
 <% end -%>
 <% end -%>
 
+ExecReload=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> reload
 ExecStart=/usr/bin/java $JAVA_ARGS \
           '-XX:OnOutOfMemoryError=kill -9 %%p' \
           -Djava.security.egd=/dev/urandom \

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
@@ -22,7 +22,7 @@ PermissionsStartOnly=true
 ExecStartPre=<%= action %>
 <% end -%>
 <% end -%>
-
+ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/bin/java $JAVA_ARGS \
           '-XX:OnOutOfMemoryError=kill -9 %%p' \
           -Djava.security.egd=/dev/urandom \

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
@@ -22,7 +22,7 @@ PermissionsStartOnly=true
 ExecStartPre=<%= action %>
 <% end -%>
 <% end -%>
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> reload
 ExecStart=/usr/bin/java $JAVA_ARGS \
           '-XX:OnOutOfMemoryError=kill -9 %%p' \
           -Djava.security.egd=/dev/urandom \

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -131,6 +131,13 @@ rh_status_q() {
     rh_status >/dev/null 2>&1
 }
 
+reload() {
+    echo -n $"Reloading $prog: "
+    killproc -p $PIDFILE $prog -HUP
+    RETVAL=$?
+    echo
+    return $RETVAL
+}
 
 case "$1" in
     start)
@@ -148,11 +155,14 @@ case "$1" in
         rh_status_q || exit 0
         restart
         ;;
+    reload)
+        $1
+        ;;
     status)
         rh_status
         ;;
     *)
-        echo $"Usage: $0 {start|stop|restart|condrestart|try-restart|status}"
+        echo $"Usage: $0 {start|stop|restart|condrestart|try-restart|reload|status}"
         exit 2
 esac
 exit $?

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -133,7 +133,7 @@ rh_status_q() {
 
 reload() {
     echo -n $"Reloading $prog: "
-    killproc -p $PIDFILE $prog -HUP
+    /opt/puppetlabs/server/apps/${realname}/bin/${realname} reload
     RETVAL=$?
     echo
     return $RETVAL

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -154,13 +154,8 @@ do_restart()
 # Function that sends a SIGHUP to the daemon/service
 #
 do_reload() {
-     #
-     # If the daemon can reload its configuration without
-     # restarting (for example, when it is sent a SIGHUP),
-     # then implement that here.
-     #
-     start-stop-daemon --stop --signal HUP --quiet --pidfile $PIDFILE --name $NAME
-     return 0
+     /opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME} reload
+     echo $?
 }
 
 case "$1" in

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -150,6 +150,19 @@ do_restart()
     esac
 }
 
+#
+# Function that sends a SIGHUP to the daemon/service
+#
+do_reload() {
+     #
+     # If the daemon can reload its configuration without
+     # restarting (for example, when it is sent a SIGHUP),
+     # then implement that here.
+     #
+     start-stop-daemon --stop --signal HUP --quiet --pidfile $PIDFILE --name $NAME
+     return 0
+}
+
 case "$1" in
     start)
         [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
@@ -175,16 +188,17 @@ case "$1" in
         get_status_q || exit 0
         do_restart
         ;;
-    restart|force-reload)
-        #
-        # If the "reload" option is implemented then remove the
-        # 'force-reload' alias
-        #
+    restart)
         [ "$VERBOSE" != no ] && log_daemon_msg "Restarting $DESC" "$NAME"
         do_restart
         ;;
+    force-reload|reload)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Reloading $DESC" "$NAME"
+        do_reload
+        log_end_msg $?
+        ;;
     *)
-        echo "Usage: $SCRIPTNAME {start|stop|status|condrestart|try-restart|restart|force-reload}" >&2
+        echo "Usage: $SCRIPTNAME {start|stop|status|condrestart|try-restart|restart|force-reload|reload}" >&2
         exit 3
         ;;
 esac

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -203,4 +203,4 @@ case "$1" in
         ;;
 esac
 
-:
+exit 0

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
@@ -23,6 +23,7 @@ ExecStartPre=<%= action %>
 <% end -%>
 <% end -%>
 
+ExecReload=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> reload
 ExecStart=/opt/puppetlabs/server/bin/java $JAVA_ARGS \
           '-XX:OnOutOfMemoryError=kill -9 %%p' \
           -Djava.security.egd=/dev/urandom \

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
@@ -23,7 +23,7 @@ ExecStartPre=<%= action %>
 <% end -%>
 <% end -%>
 
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> reload
 ExecStart=/opt/puppetlabs/server/bin/java $JAVA_ARGS \
           '-XX:OnOutOfMemoryError=kill -9 %%p' \
           -Djava.security.egd=/dev/urandom \

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
@@ -23,6 +23,7 @@ ExecStartPre=<%= action %>
 <% end -%>
 <% end -%>
 
+ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/opt/puppetlabs/server/bin/java $JAVA_ARGS \
           '-XX:OnOutOfMemoryError=kill -9 %%p' \
           -Djava.security.egd=/dev/urandom \

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -131,6 +131,13 @@ rh_status_q() {
     rh_status >/dev/null 2>&1
 }
 
+reload() {
+    echo -n $"Reloading $prog: "
+    killproc -p $PIDFILE $prog -HUP
+    RETVAL=$?
+    echo
+    return $RETVAL
+}
 
 case "$1" in
     start)
@@ -148,11 +155,14 @@ case "$1" in
         rh_status_q || exit 0
         restart
         ;;
+    reload)
+        $1
+        ;;
     status)
         rh_status
         ;;
     *)
-        echo $"Usage: $0 {start|stop|restart|condrestart|try-restart|status}"
+        echo $"Usage: $0 {start|stop|restart|condrestart|try-restart|reload|status}"
         exit 2
 esac
 exit $?

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -133,7 +133,7 @@ rh_status_q() {
 
 reload() {
     echo -n $"Reloading $prog: "
-    killproc -p $PIDFILE $prog -HUP
+    /opt/puppetlabs/server/apps/${realname}/bin/${realname} reload
     RETVAL=$?
     echo
     return $RETVAL

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -166,6 +166,12 @@ sl_status() {
     rc_status -v
 }
 
+reload() {
+    echo -n $"Reloading ${prog}:"
+    killproc -p "${PIDFILE}" "$prog" -HUP
+    rc_status -v
+}
+
 
 case "$1" in
     start)
@@ -183,11 +189,14 @@ case "$1" in
         sl_status_q || exit 0
         restart
         ;;
+    reload|force-reload)
+        reload
+        ;;
     status)
         sl_status
         ;;
     *)
-        echo $"Usage: ${0} {start|stop|restart|condrestart|try-restart|status}"
+        echo $"Usage: ${0} {start|stop|restart|condrestart|try-restart|reload|force-reload|status}"
         exit 2
 esac
 exit $?


### PR DESCRIPTION
Previously, service reload was not supported. After adding support for reload in Trapperkeeper, this PR updates the init scripts to call the new `puppetserver reload` CLI instead. This reload will restart the service without exiting the JVM process and return a 0 exit code depending on whether or not the restart was successful. 