### PR TITLE
(EZ-70) Modify service 'start' functionality to use new TK 'start' subcommand

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -58,37 +58,8 @@ EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -Djava.security.egd=/dev/u
 #
 do_start()
 {
-    <% if EZBake::Config[:open_file_limit] -%>
-    [ -n "$OPEN_FILE_LIMIT" ] && ulimit -n $OPEN_FILE_LIMIT
-    <% end -%>
-
-    <% EZBake::Config[:debian][:pre_start_action].each do |action| -%>
-    <%= action %>
-    <% end -%>
-
-    if [ ! -d  "/var/run/puppetlabs/$NAME" ] ; then
-      mkdir -p /var/run/puppetlabs/$NAME
-      chown -R $USER:$GROUP /var/run/puppetlabs/$NAME
-    fi
-
-    start-stop-daemon --start $EXTRA_ARGS --quiet --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR --exec $JAVA_BIN \
-      --startas /bin/bash -- -c "exec $EXEC >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1"
+    /opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
     retval=$?
-
-    if [ "$retval" -ne 0 ] \
-        || ! wait_for_pidfile $PIDFILE 5 \
-        || ! wait_for_app $(cat $PIDFILE) $START_TIMEOUT ;then
-        retval=2
-    fi
-
-    <% if not EZBake::Config[:debian][:post_start_action].empty? -%>
-    if [ "$retval" -eq 0 ]; then
-    <% EZBake::Config[:debian][:post_start_action].each do |action| -%>
-        <%= action %>
-    <% end -%>
-    fi
-    <% end -%>
-
     return $retval
 }
 
@@ -127,7 +98,6 @@ get_status_q()
     get_status >/dev/null 2>&1
 }
 
-
 #
 # Function that restarts the daemon/service
 #
@@ -148,6 +118,14 @@ do_restart()
             log_end_msg 1
             ;;
     esac
+}
+
+#
+# Function that sends a SIGHUP to the daemon/service
+#
+do_reload() {
+    /opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME} reload
+    return $?
 }
 
 case "$1" in
@@ -175,18 +153,19 @@ case "$1" in
         get_status_q || exit 0
         do_restart
         ;;
-    restart|force-reload)
-        #
-        # If the "reload" option is implemented then remove the
-        # 'force-reload' alias
-        #
+    restart)
         [ "$VERBOSE" != no ] && log_daemon_msg "Restarting $DESC" "$NAME"
         do_restart
         ;;
+    force-reload|reload)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Reloading $DESC" "$NAME"
+        do_reload
+        log_end_msg $?
+        ;;
     *)
-        echo "Usage: $SCRIPTNAME {start|stop|status|condrestart|try-restart|restart|force-reload}" >&2
+        echo "Usage: $SCRIPTNAME {start|stop|status|condrestart|try-restart|restart|force-reload|reload}" >&2
         exit 3
         ;;
 esac
 
-:
+exit $?

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -62,7 +62,7 @@ do_start()
     <%= action %>
     <% end -%>
 
-    start-stop-daemon --start --chuid $USER --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR \
+    start-stop-daemon --start --quiet --chuid $USER --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR \
       --startas "/opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME}" -- start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1
     retval=$?
 

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -66,8 +66,8 @@ do_start()
     <%= action %>
     <% end -%>
 
-    start-stop-daemon --start $EXTRA_ARGS --quiet --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR --exec $JAVA_BIN \
-      --startas /bin/bash -- -c "/opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME} start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1"
+    start-stop-daemon --start --chuid puppet --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR \
+      --startas "/opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME}" -- start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1
     retval=$?
 
     <% if not EZBake::Config[:debian][:post_start_action].empty? -%>

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -66,7 +66,8 @@ do_start()
     <%= action %>
     <% end -%>
 
-    /opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME} start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1
+    start-stop-daemon --start $EXTRA_ARGS --quiet --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR --exec $JAVA_BIN \
+      --startas /bin/bash -- -c "/opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME} start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1"
     retval=$?
 
     <% if not EZBake::Config[:debian][:post_start_action].empty? -%>

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -58,8 +58,25 @@ EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -Djava.security.egd=/dev/u
 #
 do_start()
 {
-    /opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
+    <% if EZBake::Config[:open_file_limit] -%>
+    [ -n "$OPEN_FILE_LIMIT" ] && ulimit -n $OPEN_FILE_LIMIT
+    <% end -%>
+
+    <% EZBake::Config[:debian][:pre_start_action].each do |action| -%>
+    <%= action %>
+    <% end -%>
+
+    /opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME} start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1
     retval=$?
+
+    <% if not EZBake::Config[:debian][:post_start_action].empty? -%>
+    if [ "$retval" -eq 0 ]; then
+    <% EZBake::Config[:debian][:post_start_action].each do |action| -%>
+        <%= action %>
+    <% end -%>
+    fi
+    <% end -%>
+
     return $retval
 }
 

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -38,10 +38,6 @@ PIDFILE=/var/run/puppetlabs/${REALNAME}/${REALNAME}.pid
 SCRIPTNAME=/etc/init.d/$NAME
 START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 
-JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b '${BOOTSTRAP_CONFIG}'"
-EXTRA_ARGS="--chuid $USER --background --make-pidfile"
-EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -Djava.security.egd=/dev/urandom $JAVA_ARGS"
-
 # Exit if the package is not installed
 [ -x "$JAVA_BIN" ] || exit 0
 
@@ -66,7 +62,7 @@ do_start()
     <%= action %>
     <% end -%>
 
-    start-stop-daemon --start --chuid puppet --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR \
+    start-stop-daemon --start --chuid $USER --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR \
       --startas "/opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME}" -- start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1
     retval=$?
 

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
@@ -10,7 +10,7 @@ TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
 Restart=on-failure
 StartLimitBurst=5
-PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>
+PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>.pid
 #set default privileges to -rw-r-----
 UMask=027
 <% if EZBake::Config[:open_file_limit] -%>

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
@@ -29,8 +29,6 @@ ExecStart=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= 
 
 KillMode=process
 
-ExecStartPost=/bin/bash "${INSTALL_DIR}/ezbake-functions.sh" wait_for_app
-
 <% EZBake::Config[:debian][:post_start_action].each do |action| -%>
 ExecStartPost=-<%= action %>
 <% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
@@ -3,13 +3,14 @@ Description=<%= EZBake::Config[:project] %> Service
 After=syslog.target network.target
 
 [Service]
-Type=simple
+Type=forking
 EnvironmentFile=/etc/default/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
 Restart=on-failure
 StartLimitBurst=5
+PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>
 #set default privileges to -rw-r-----
 UMask=027
 <% if EZBake::Config[:open_file_limit] -%>
@@ -23,13 +24,8 @@ ExecStartPre=<%= action %>
 <% end -%>
 <% end -%>
 
-ExecStart=/usr/bin/java $JAVA_ARGS \
-          '-XX:OnOutOfMemoryError=kill -9 %%p' \
-          -Djava.security.egd=/dev/urandom \
-          -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" clojure.main \
-          -m <%= EZBake::Config[:main_namespace] %> \
-          --config "${CONFIG}" \
-          -b "${BOOTSTRAP_CONFIG}" $@
+ExecReload=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> reload
+ExecStart=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
 
 KillMode=process
 

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
@@ -10,7 +10,7 @@ TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
 Restart=on-failure
 StartLimitBurst=5
-PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>
+PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>.pid
 #set default privileges to -rw-r-----
 UMask=027
 <% if EZBake::Config[:open_file_limit] -%>

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
@@ -3,13 +3,14 @@ Description=<%= EZBake::Config[:project] %> Service
 After=syslog.target network.target
 
 [Service]
-Type=simple
+Type=forking
 EnvironmentFile=/etc/sysconfig/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
 Restart=on-failure
 StartLimitBurst=5
+PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>
 #set default privileges to -rw-r-----
 UMask=027
 <% if EZBake::Config[:open_file_limit] -%>
@@ -23,17 +24,10 @@ ExecStartPre=<%= action %>
 <% end -%>
 <% end -%>
 
-ExecStart=/usr/bin/java $JAVA_ARGS \
-          '-XX:OnOutOfMemoryError=kill -9 %%p' \
-          -Djava.security.egd=/dev/urandom \
-          -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" clojure.main \
-          -m <%= EZBake::Config[:main_namespace] %> \
-          --config "${CONFIG}" \
-          -b "${BOOTSTRAP_CONFIG}" $@
+ExecReload=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> reload
+ExecStart=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
 
 KillMode=process
-
-ExecStartPost=/bin/bash "${INSTALL_DIR}/ezbake-functions.sh" wait_for_app
 
 <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
 ExecStartPost=-<%= action %>

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -46,7 +46,7 @@ JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBa
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile=/var/lock/subsys/$prog
 EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -Djava.security.egd=/dev/urandom $JAVA_ARGS"
-PIDFILE="/var/run/puppetlabs/${realname}/${realname}"
+PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 
 find_my_pid() {
@@ -126,7 +126,10 @@ reload() {
     echo -n $"Reloading $prog: "
     /opt/puppetlabs/server/apps/${realname}/bin/${realname} reload
     RETVAL=$?
+
+    [ $RETVAL -eq 0 ] && success $"$base stopped" || failure $"$base stopped"
     echo
+    [ $RETVAL -eq 0 ] && rm -f $lockfile $PIDFILE
     return $RETVAL
 }
 

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -42,10 +42,7 @@ config=$CONFIG
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 JARFILE="<%= EZBake::Config[:uberjar_name] %>"
-JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b '${BOOTSTRAP_CONFIG}'"
-EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile=/var/lock/subsys/$prog
-EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -Djava.security.egd=/dev/urandom $JAVA_ARGS"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -59,8 +59,36 @@ find_my_pid() {
 }
 
 start() {
-    /opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
+    # call status here and figure out current state
+    rh_status_q
+    [ -x $JAVA_BIN ] || exit 5
+    [ -e $config ] || exit 6
+    # Move any heap dumps aside
+    echo -n $"Starting $prog: "
+
+    <% if EZBake::Config[:open_file_limit] -%>
+    [ -n "$OPEN_FILE_LIMIT" ] && ulimit -n $OPEN_FILE_LIMIT
+    <% end -%>
+
+    <% EZBake::Config[:redhat][:pre_start_action].each do |action| -%>
+    <%= action %>
+    <% end -%>
+
+    /opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1
     retval=$?
+
+    [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"
+    echo
+    [ -s $PIDFILE ] && touch $lockfile
+
+    <% if not EZBake::Config[:redhat][:post_start_action].empty? -%>
+    if [ "$retval" -eq 0 ]; then
+    <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
+        <%= action %>
+    <% end -%>
+    fi
+    <% end -%>
+
     return $retval
 }
 

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -73,8 +73,8 @@ start() {
 
     pushd "${INSTALL_DIR}" &> /dev/null
     daemon --user $USER --pidfile $PIDFILE "/opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1"
-    popd &> /dev/null
     retval=$?
+    popd &> /dev/null
     [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"
     echo
     [ -s $PIDFILE ] && touch $lockfile

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -59,44 +59,8 @@ find_my_pid() {
 }
 
 start() {
-    # call status here and figure out current state
-    rh_status_q
-    [ -x $JAVA_BIN ] || exit 5
-    [ -e $config ] || exit 6
-    # Move any heap dumps aside
-    echo -n $"Starting $prog: "
-
-    <% if EZBake::Config[:open_file_limit] -%>
-    [ -n "$OPEN_FILE_LIMIT" ] && ulimit -n $OPEN_FILE_LIMIT
-    <% end -%>
-
-    <% EZBake::Config[:redhat][:pre_start_action].each do |action| -%>
-    <%= action %>
-    <% end -%>
-
-    pushd "${INSTALL_DIR}" &> /dev/null
-    daemon --user $USER --pidfile $PIDFILE "$EXEC >> /var/log/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>-daemon.log 2>&1 &"
+    /opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
     retval=$?
-    sleep 1
-    popd &> /dev/null
-    find_my_pid
-    [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"
-    echo
-    [ -s $PIDFILE ] && touch $lockfile
-
-    if [ "$retval" -ne 0 ] \
-        || ! wait_for_app $(cat $PIDFILE) $START_TIMEOUT ;then
-        failure $"$base startup"
-    fi
-
-    <% if not EZBake::Config[:redhat][:post_start_action].empty? -%>
-    if [ "$retval" -eq 0 ]; then
-    <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
-        <%= action %>
-    <% end -%>
-    fi
-    <% end -%>
-
     return $retval
 }
 
@@ -131,6 +95,13 @@ rh_status_q() {
     rh_status >/dev/null 2>&1
 }
 
+reload() {
+    echo -n $"Reloading $prog: "
+    /opt/puppetlabs/server/apps/${realname}/bin/${realname} reload
+    RETVAL=$?
+    echo
+    return $RETVAL
+}
 
 case "$1" in
     start)
@@ -148,11 +119,14 @@ case "$1" in
         rh_status_q || exit 0
         restart
         ;;
+    reload)
+        $1
+        ;;
     status)
         rh_status
         ;;
     *)
-        echo $"Usage: $0 {start|stop|restart|condrestart|try-restart|status}"
+        echo $"Usage: $0 {start|stop|restart|condrestart|try-restart|reload|status}"
         exit 2
 esac
 exit $?

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -74,7 +74,7 @@ start() {
     <%= action %>
     <% end -%>
 
-    /opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1
+    daemon --user $USER --pidfile $PIDFILE "/opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1"
     retval=$?
     [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"
     echo

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -71,7 +71,9 @@ start() {
     <%= action %>
     <% end -%>
 
+    pushd "${INSTALL_DIR}" &> /dev/null
     daemon --user $USER --pidfile $PIDFILE "/opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1"
+    popd &> /dev/null
     retval=$?
     [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"
     echo
@@ -124,9 +126,8 @@ reload() {
     /opt/puppetlabs/server/apps/${realname}/bin/${realname} reload
     RETVAL=$?
 
-    [ $RETVAL -eq 0 ] && success $"$base stopped" || failure $"$base reloaded"
+    [ $RETVAL -eq 0 ] && success $"$base reloaded" || failure $"$base reloaded"
     echo
-    [ $RETVAL -eq 0 ] && rm -f $lockfile $PIDFILE
     return $RETVAL
 }
 

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -76,7 +76,6 @@ start() {
 
     /opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1
     retval=$?
-
     [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"
     echo
     [ -s $PIDFILE ] && touch $lockfile

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -124,7 +124,7 @@ reload() {
     /opt/puppetlabs/server/apps/${realname}/bin/${realname} reload
     RETVAL=$?
 
-    [ $RETVAL -eq 0 ] && success $"$base stopped" || failure $"$base stopped"
+    [ $RETVAL -eq 0 ] && success $"$base stopped" || failure $"$base reloaded"
     echo
     [ $RETVAL -eq 0 ] && rm -f $lockfile $PIDFILE
     return $RETVAL

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -20,8 +20,8 @@ if [ ! -e "$restartfile" ]; then
     mkdir -p "$dir"
     echo -n "0" > "$restartfile"
 elif [ ! -r "$restartfile" ] || [ ! -w "$restartfile" ]; then
-        echo "The restart-file at <%= EZBake::Config[:restart_file] %> is not readable and/or writeable." 1>&2
-        exit 1
+    echo "The restart-file at <%= EZBake::Config[:restart_file] %> is not readable and/or writeable." 1>&2
+    exit 1
 fi
 
 ${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=/dev/urandom -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> clojure.main -m <%= EZBake::Config[:main_namespace] %> --config "${CONFIG}" -b "${BOOTSTRAP_CONFIG}" &

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -18,7 +18,7 @@ find_my_pid() {
 
 if [ ! -e "$restartfile" ]; then
     mkdir -p "$dir"
-    echo "1" > "$restartfile"
+    echo -n "0" > "$restartfile"
 elif [ ! -r "$restartfile" ] || [ ! -w "$restartfile" ]; then
         echo "The restart-file at <%= EZBake::Config[:restart_file] %> is not readable and/or writeable." >2
         exit 1
@@ -41,9 +41,4 @@ while [ "$cur" == "$initial" ] ;do
 done
 
 find_my_pid
-
-pid=`cat $PIDFILE`
-source "${INSTALL_DIR}/ezbake-functions.sh"
-wait_for_app $pid 300
-
 exit 0

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -4,7 +4,8 @@ set -e
 restartfile=<%= EZBake::Config[:restart_file] %>
 timeout=<%= EZBake::Config[:start_timeout] %>
 dir=$(dirname "$restartfile")
-PIDFILE=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>
+realname="<%= EZBake::Config[:real_name] %>"
+PIDFILE="/var/run/puppetlabs/${realname}/${realname}"
 
 find_my_pid() {
     pid=`pgrep -f <%= EZBake::Config[:uberjar_name] %>`
@@ -18,11 +19,9 @@ find_my_pid() {
 if [ ! -e "$restartfile" ]; then
     mkdir -p "$dir"
     echo "1" > "$restartfile"
-else
-    if [ ! -r "$restartfile" ] || [ ! -w "$restartfile" ]; then
+elif [ ! -r "$restartfile" ] || [ ! -w "$restartfile" ]; then
         echo "The restart-file at <%= EZBake::Config[:restart_file] %> is not readable and/or writeable." >2
         exit 1
-    fi
 fi
 
 ${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=/dev/urandom -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> clojure.main -m <%= EZBake::Config[:main_namespace] %> --config "${CONFIG}" -b "${BOOTSTRAP_CONFIG}" &

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -20,7 +20,7 @@ if [ ! -e "$restartfile" ]; then
     mkdir -p "$dir"
     echo -n "0" > "$restartfile"
 elif [ ! -r "$restartfile" ] || [ ! -w "$restartfile" ]; then
-        echo "The restart-file at <%= EZBake::Config[:restart_file] %> is not readable and/or writeable." >2
+        echo "The restart-file at <%= EZBake::Config[:restart_file] %> is not readable and/or writeable." 1>&2
         exit 1
 fi
 
@@ -35,7 +35,7 @@ while [ "$cur" == "$initial" ] ;do
 
     ((timeout--))
     if [ "$timeout" = 0 ]; then
-        echo "Startup timed out after <%= EZBake::Config[:start_timeout] %> seconds" >2
+        echo "Startup timed out after <%= EZBake::Config[:start_timeout] %> seconds" 1>&2
         exit 1
     fi
 done

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -4,15 +4,25 @@ set -e
 restartfile=<%= EZBake::Config[:restart_file] %>
 timeout=<%= EZBake::Config[:start_timeout] %>
 dir=$(dirname "$restartfile")
+PIDFILE=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>
 
-if [ ! -r "$restartfile" ] || [ ! -w "$restartfile" ]; then
-    echo "The restart-file at <%= EZBake::Config[:restart_file] %> is not readable and/or writeable."
-    exit 1
-fi
+find_my_pid() {
+    pid=`pgrep -f <%= EZBake::Config[:uberjar_name] %>`
+    if [ ! -d  "/var/run/puppetlabs/${realname}" ] ; then
+        mkdir -p /var/run/puppetlabs/${realname}
+        chown -R $USER:$GROUP /var/run/puppetlabs/${realname}
+    fi
+    echo $pid > $PIDFILE
+}
 
 if [ ! -e "$restartfile" ]; then
     mkdir -p "$dir"
     echo "1" > "$restartfile"
+else
+    if [ ! -r "$restartfile" ] || [ ! -w "$restartfile" ]; then
+        echo "The restart-file at <%= EZBake::Config[:restart_file] %> is not readable and/or writeable." >2
+        exit 1
+    fi
 fi
 
 ${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=/dev/urandom -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> clojure.main -m <%= EZBake::Config[:main_namespace] %> --config "${CONFIG}" -b "${BOOTSTRAP_CONFIG}" &
@@ -26,9 +36,15 @@ while [ "$cur" == "$initial" ] ;do
 
     ((timeout--))
     if [ "$timeout" = 0 ]; then
-        echo "Startup timed out after <%= EZBake::Config[:start_timeout] %> seconds"
+        echo "Startup timed out after <%= EZBake::Config[:start_timeout] %> seconds" >2
         exit 1
     fi
 done
+
+find_my_pid
+
+pid=`cat $PIDFILE`
+source "${INSTALL_DIR}/ezbake-functions.sh"
+wait_for_app $pid 300
 
 exit 0

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -5,7 +5,7 @@ restartfile=<%= EZBake::Config[:restart_file] %>
 timeout=<%= EZBake::Config[:start_timeout] %>
 dir=$(dirname "$restartfile")
 realname="<%= EZBake::Config[:real_name] %>"
-PIDFILE="/var/run/puppetlabs/${realname}/${realname}"
+PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 
 find_my_pid() {
     pid=`pgrep -f <%= EZBake::Config[:uberjar_name] %>`

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -65,8 +65,8 @@ do_start()
     <% EZBake::Config[:debian][:pre_start_action].each do |action| -%>
     <%= action %>
     <% end -%>
-    start-stop-daemon --start $EXTRA_ARGS --quiet --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR --exec $JAVA_BIN \
-        --startas /bin/bash -- -c "/opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME} start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1"
+    start-stop-daemon --start --chuid puppet --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR \
+      --startas "/opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME}" -- start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1
     retval=$?
 
     <% if not EZBake::Config[:debian][:post_start_action].empty? -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -62,7 +62,7 @@ do_start()
     <%= action %>
     <% end -%>
 
-    start-stop-daemon --start --chuid $USER --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR \
+    start-stop-daemon --start --quiet --chuid $USER --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR \
       --startas "/opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME}" -- start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1
     retval=$?
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -38,10 +38,6 @@ PIDFILE=/var/run/puppetlabs/${REALNAME}/${REALNAME}.pid
 SCRIPTNAME=/etc/init.d/$NAME
 START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 
-JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b '${BOOTSTRAP_CONFIG}'"
-EXTRA_ARGS="--chuid $USER --background --make-pidfile"
-EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -Djava.security.egd=/dev/urandom $JAVA_ARGS"
-
 # Exit if the package is not installed
 [ -x "$JAVA_BIN" ] || exit 0
 
@@ -65,7 +61,8 @@ do_start()
     <% EZBake::Config[:debian][:pre_start_action].each do |action| -%>
     <%= action %>
     <% end -%>
-    start-stop-daemon --start --chuid puppet --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR \
+
+    start-stop-daemon --start --chuid $USER --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR \
       --startas "/opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME}" -- start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1
     retval=$?
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -65,8 +65,8 @@ do_start()
     <% EZBake::Config[:debian][:pre_start_action].each do |action| -%>
     <%= action %>
     <% end -%>
-
-    /opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME} start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1
+    start-stop-daemon --start $EXTRA_ARGS --quiet --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR --exec $JAVA_BIN \
+        --startas /bin/bash -- -c "/opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME} start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1"
     retval=$?
 
     <% if not EZBake::Config[:debian][:post_start_action].empty? -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -58,8 +58,25 @@ EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -Djava.security.egd=/dev/u
 #
 do_start()
 {
-    /opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
+    <% if EZBake::Config[:open_file_limit] -%>
+    [ -n "$OPEN_FILE_LIMIT" ] && ulimit -n $OPEN_FILE_LIMIT
+    <% end -%>
+
+    <% EZBake::Config[:debian][:pre_start_action].each do |action| -%>
+    <%= action %>
+    <% end -%>
+
+    /opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME} start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1
     retval=$?
+
+    <% if not EZBake::Config[:debian][:post_start_action].empty? -%>
+    if [ "$retval" -eq 0 ]; then
+    <% EZBake::Config[:debian][:post_start_action].each do |action| -%>
+        <%= action %>
+    <% end -%>
+    fi
+    <% end -%>
+
     return $retval
 }
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -58,37 +58,8 @@ EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -Djava.security.egd=/dev/u
 #
 do_start()
 {
-    <% if EZBake::Config[:open_file_limit] -%>
-    [ -n "$OPEN_FILE_LIMIT" ] && ulimit -n $OPEN_FILE_LIMIT
-    <% end -%>
-
-    <% EZBake::Config[:debian][:pre_start_action].each do |action| -%>
-    <%= action %>
-    <% end -%>
-
-    if [ ! -d  "/var/run/puppetlabs/$REALNAME" ] ; then
-      mkdir -p /var/run/puppetlabs/$REALNAME
-      chown -R $USER:$GROUP /var/run/puppetlabs/$REALNAME
-    fi
-
-    start-stop-daemon --start $EXTRA_ARGS --quiet --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR --exec $JAVA_BIN \
-      --startas /bin/bash -- -c "exec $EXEC >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1"
+    /opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
     retval=$?
-
-    if [ "$retval" -ne 0 ] \
-        || ! wait_for_pidfile $PIDFILE 5 \
-        || ! wait_for_app $(cat $PIDFILE) $START_TIMEOUT ;then
-        retval=2
-    fi
-
-    <% if not EZBake::Config[:debian][:post_start_action].empty? -%>
-    if [ "$retval" -eq 0 ]; then
-    <% EZBake::Config[:debian][:post_start_action].each do |action| -%>
-        <%= action %>
-    <% end -%>
-    fi
-    <% end -%>
-
     return $retval
 }
 
@@ -150,6 +121,14 @@ do_restart()
     esac
 }
 
+#
+# Function that sends a SIGHUP to the daemon/service
+#
+do_reload() {
+    /opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME} reload
+    return $?
+}
+
 case "$1" in
     start)
         [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
@@ -175,18 +154,19 @@ case "$1" in
         get_status_q || exit 0
         do_restart
         ;;
-    restart|force-reload)
-        #
-        # If the "reload" option is implemented then remove the
-        # 'force-reload' alias
-        #
+    restart)
         [ "$VERBOSE" != no ] && log_daemon_msg "Restarting $DESC" "$NAME"
         do_restart
         ;;
+    force-reload|reload)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Reloading $DESC" "$NAME"
+        do_reload
+        log_end_msg $?
+        ;;
     *)
-        echo "Usage: $SCRIPTNAME {start|stop|status|condrestart|try-restart|restart|force-reload}" >&2
+        echo "Usage: $SCRIPTNAME {start|stop|status|condrestart|try-restart|restart|force-reload|reload}" >&2
         exit 3
         ;;
 esac
 
-:
+exit $?

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
@@ -10,7 +10,7 @@ TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
 Restart=on-failure
 StartLimitBurst=5
-PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>
+PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>.pid
 #set default privileges to -rw-r-----
 UMask=027
 <% if EZBake::Config[:open_file_limit] -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
@@ -29,8 +29,6 @@ ExecStart=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= 
 
 KillMode=process
 
-ExecStartPost=/bin/bash "${INSTALL_DIR}/ezbake-functions.sh" wait_for_app
-
 <% EZBake::Config[:debian][:post_start_action].each do |action| -%>
 ExecStartPost=-<%= action %>
 <% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
@@ -3,13 +3,14 @@ Description=<%= EZBake::Config[:project] %> Service
 After=syslog.target network.target
 
 [Service]
-Type=simple
+Type=forking
 EnvironmentFile=/etc/default/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
 Restart=on-failure
 StartLimitBurst=5
+PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>
 #set default privileges to -rw-r-----
 UMask=027
 <% if EZBake::Config[:open_file_limit] -%>
@@ -23,13 +24,8 @@ ExecStartPre=<%= action %>
 <% end -%>
 <% end -%>
 
-ExecStart=/opt/puppetlabs/server/bin/java $JAVA_ARGS \
-          '-XX:OnOutOfMemoryError=kill -9 %%p' \
-          -Djava.security.egd=/dev/urandom \
-          -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" clojure.main \
-          -m <%= EZBake::Config[:main_namespace] %> \
-          --config "${CONFIG}" \
-          -b "${BOOTSTRAP_CONFIG}" $@
+ExecReload=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> reload
+ExecStart=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
 
 KillMode=process
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
@@ -10,7 +10,7 @@ TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
 Restart=on-failure
 StartLimitBurst=5
-PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>
+PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>.pid
 #set default privileges to -rw-r-----
 UMask=027
 <% if EZBake::Config[:open_file_limit] -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
@@ -29,8 +29,6 @@ ExecStart=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= 
 
 KillMode=process
 
-ExecStartPost=/bin/bash "${INSTALL_DIR}/ezbake-functions.sh" wait_for_app
-
 <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
 ExecStartPost=-<%= action %>
 <% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
@@ -3,13 +3,14 @@ Description=<%= EZBake::Config[:project] %> Service
 After=syslog.target network.target <%= EZBake::Config[:start_after].map {|dep| "#{dep}.service" }.join(" ") %>
 
 [Service]
-Type=simple
+Type=forking
 EnvironmentFile=/etc/sysconfig/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
 TimeoutStopSec=60
 Restart=on-failure
 StartLimitBurst=5
+PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>
 #set default privileges to -rw-r-----
 UMask=027
 <% if EZBake::Config[:open_file_limit] -%>
@@ -23,13 +24,8 @@ ExecStartPre=<%= action %>
 <% end -%>
 <% end -%>
 
-ExecStart=/opt/puppetlabs/server/bin/java $JAVA_ARGS \
-          '-XX:OnOutOfMemoryError=kill -9 %%p' \
-          -Djava.security.egd=/dev/urandom \
-          -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" clojure.main \
-          -m <%= EZBake::Config[:main_namespace] %> \
-          --config "${CONFIG}" \
-          -b "${BOOTSTRAP_CONFIG}" $@
+ExecReload=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> reload
+ExecStart=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
 
 KillMode=process
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -125,7 +125,7 @@ reload() {
     /opt/puppetlabs/server/apps/${realname}/bin/${realname} reload
     RETVAL=$?
 
-    [ $RETVAL -eq 0 ] && success $"$base stopped" || failure $"$base stopped"
+    [ $RETVAL -eq 0 ] && success $"$base stopped" || failure $"$base reloaded"
     echo
     [ $RETVAL -eq 0 ] && rm -f $lockfile $PIDFILE
     return $RETVAL

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -42,10 +42,7 @@ config=$CONFIG
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 JARFILE="<%= EZBake::Config[:uberjar_name] %>"
-JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b '${BOOTSTRAP_CONFIG}'"
-EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile=/var/lock/subsys/$prog
-EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -Djava.security.egd=/dev/urandom $JAVA_ARGS"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -71,9 +71,10 @@ start() {
     <%= action %>
     <% end -%>
 
+    pushd "${INSTALL_DIR}" &> /dev/null
     daemon --user $USER --pidfile $PIDFILE "/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start"
+    popd &> /dev/null
     retval=$?
-
     [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"
     echo
     [ -s $PIDFILE ] && touch $lockfile
@@ -125,9 +126,8 @@ reload() {
     /opt/puppetlabs/server/apps/${realname}/bin/${realname} reload
     RETVAL=$?
 
-    [ $RETVAL -eq 0 ] && success $"$base stopped" || failure $"$base reloaded"
+    [ $RETVAL -eq 0 ] && success $"$base reloaded" || failure $"$base reloaded"
     echo
-    [ $RETVAL -eq 0 ] && rm -f $lockfile $PIDFILE
     return $RETVAL
 }
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -46,7 +46,7 @@ JAVA_ARGS="${JAVA_ARGS} -cp '${INSTALL_DIR}/${JARFILE}' clojure.main -m <%= EZBa
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile=/var/lock/subsys/$prog
 EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" -Djava.security.egd=/dev/urandom $JAVA_ARGS"
-PIDFILE="/var/run/puppetlabs/${realname}/${realname}"
+PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 
 find_my_pid() {
@@ -127,7 +127,10 @@ reload() {
     echo -n $"Reloading $prog: "
     /opt/puppetlabs/server/apps/${realname}/bin/${realname} reload
     RETVAL=$?
+
+    [ $RETVAL -eq 0 ] && success $"$base stopped" || failure $"$base stopped"
     echo
+    [ $RETVAL -eq 0 ] && rm -f $lockfile $PIDFILE
     return $RETVAL
 }
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -59,44 +59,8 @@ find_my_pid() {
 }
 
 start() {
-    # call status here and figure out current state
-    rh_status_q
-    [ -x $JAVA_BIN ] || exit 5
-    [ -e $config ] || exit 6
-    # Move any heap dumps aside
-    echo -n $"Starting $prog: "
-
-    <% if EZBake::Config[:open_file_limit] -%>
-    [ -n "$OPEN_FILE_LIMIT" ] && ulimit -n $OPEN_FILE_LIMIT
-    <% end -%>
-
-    <% EZBake::Config[:redhat][:pre_start_action].each do |action| -%>
-    <%= action %>
-    <% end -%>
-
-    pushd "${INSTALL_DIR}" &> /dev/null
-    daemon --user $USER --pidfile $PIDFILE "$EXEC >> /var/log/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>-daemon.log 2>&1 &"
+    /opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
     retval=$?
-    sleep 1
-    popd &> /dev/null
-    find_my_pid
-    [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"
-    echo
-    [ -s $PIDFILE ] && touch $lockfile
-
-    if [ "$retval" -ne 0 ] \
-        || ! wait_for_app $(cat $PIDFILE) $START_TIMEOUT ;then
-        failure $"$base startup"
-    fi
-
-    <% if not EZBake::Config[:redhat][:post_start_action].empty? -%>
-    if [ "$retval" -eq 0 ]; then
-    <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
-        <%= action %>
-    <% end -%>
-    fi
-    <% end -%>
-
     return $retval
 }
 
@@ -131,6 +95,13 @@ rh_status_q() {
     rh_status >/dev/null 2>&1
 }
 
+reload() {
+    echo -n $"Reloading $prog: "
+    /opt/puppetlabs/server/apps/${realname}/bin/${realname} reload
+    RETVAL=$?
+    echo
+    return $RETVAL
+}
 
 case "$1" in
     start)
@@ -148,11 +119,14 @@ case "$1" in
         rh_status_q || exit 0
         restart
         ;;
+    reload)
+        $1
+        ;;
     status)
         rh_status
         ;;
     *)
-        echo $"Usage: $0 {start|stop|restart|condrestart|try-restart|status}"
+        echo $"Usage: $0 {start|stop|restart|condrestart|try-restart|reload|status}"
         exit 2
 esac
 exit $?

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -59,8 +59,36 @@ find_my_pid() {
 }
 
 start() {
+    # call status here and figure out current state
+    rh_status_q
+    [ -x $JAVA_BIN ] || exit 5
+    [ -e $config ] || exit 6
+    # Move any heap dumps aside
+    echo -n $"Starting $prog: "
+
+    <% if EZBake::Config[:open_file_limit] -%>
+    [ -n "$OPEN_FILE_LIMIT" ] && ulimit -n $OPEN_FILE_LIMIT
+    <% end -%>
+
+    <% EZBake::Config[:redhat][:pre_start_action].each do |action| -%>
+    <%= action %>
+    <% end -%>
+
     /opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
     retval=$?
+
+    [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"
+    echo
+    [ -s $PIDFILE ] && touch $lockfile
+
+    <% if not EZBake::Config[:redhat][:post_start_action].empty? -%>
+    if [ "$retval" -eq 0 ]; then
+    <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
+        <%= action %>
+    <% end -%>
+    fi
+    <% end -%>
+
     return $retval
 }
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -74,7 +74,7 @@ start() {
     <%= action %>
     <% end -%>
 
-    /opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
+    daemon --user $USER --pidfile $PIDFILE "/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start"
     retval=$?
 
     [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -73,8 +73,8 @@ start() {
 
     pushd "${INSTALL_DIR}" &> /dev/null
     daemon --user $USER --pidfile $PIDFILE "/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start"
-    popd &> /dev/null
     retval=$?
+    popd &> /dev/null
     [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"
     echo
     [ -s $PIDFILE ] && touch $lockfile

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -74,6 +74,15 @@ start() {
     <%= action %>
     <% end -%>
 
+    # startproc creates logfiles but doesn't set ownership correctly for new
+    # files. Let's always do this in case the file ownership is wrong.
+    touch "${LOGFILE}"
+    chown $USER:$USER "${LOGFILE}"
+
+    export HOME="$(getent passwd ${USER} | cut -d':' -f6)"
+
+    # startproc will change users, so make sure that user has permission
+    # to access the present working directory.
     startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" "/opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1"
     rc_status -v
     retval=$?

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -45,7 +45,7 @@ JARFILE="<%= EZBake::Config[:uberjar_name] %>"
 JAVA_ARGS="${JAVA_ARGS} -cp ${INSTALL_DIR}/${JARFILE} clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b ${BOOTSTRAP_CONFIG}"
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile="/var/lock/subsys/${prog}"
-PIDFILE="/var/run/puppetlabs/${realname}/${realname}"
+PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 LOGFILE="/var/log/puppetlabs/${realname}/${realname}.log"
 START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 
@@ -75,7 +75,7 @@ start() {
     <%= action %>
     <% end -%>
 
-    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" "/opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1"
+    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" "/opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 1>&2"
     rc_status -v
     retval=$?
 
@@ -148,6 +148,17 @@ reload() {
     echo -n $"Reloading ${prog}:"
     /opt/puppetlabs/server/apps/${realname}/bin/${realname} reload
     rc_status -v
+    retval=$?
+
+    if [ "$retval" = 0 ]; then
+        log_success_msg $"${prog} stopped"
+        echo
+        return 0
+    else
+        log_failure_msg $"${prog} could not be stopped, check ${LOGFILE}"
+        echo
+        return 1
+    fi
 }
 
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -74,7 +74,7 @@ start() {
     <%= action %>
     <% end -%>
 
-    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" "/opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 1>&2"
+    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" "/opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1"
     rc_status -v
     retval=$?
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -45,7 +45,7 @@ JARFILE="<%= EZBake::Config[:uberjar_name] %>"
 JAVA_ARGS="${JAVA_ARGS} -cp ${INSTALL_DIR}/${JARFILE} clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b ${BOOTSTRAP_CONFIG}"
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile="/var/lock/subsys/${prog}"
-PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
+PIDFILE="/var/run/puppetlabs/${realname}/${realname}"
 LOGFILE="/var/log/puppetlabs/${realname}/${realname}.log"
 START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 
@@ -62,9 +62,50 @@ print_service_pid() {
 }
 
 start() {
-    /opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
+    local service_pid
+    [ -x "${JAVA_BIN}" ] || exit 5
+    [ -e "${config}" ] || exit 6
+    echo -n $"Starting ${prog}: "
+
+    <% if EZBake::Config[:open_file_limit] -%>
+    [ -n "$OPEN_FILE_LIMIT" ] && ulimit -n $OPEN_FILE_LIMIT
+    <% end -%>
+
+    <% EZBake::Config[:redhat][:pre_start_action].each do |action| -%>
+    <%= action %>
+    <% end -%>
+
+    /opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1
+    rc_status -v
     retval=$?
-    return $retval
+
+    # If rc_status didn't succeed, bail out early without bothering to poll
+    # waiting for the application or doing work that assumes a launching state
+    if [ "$retval" != 0 ]; then
+        log_failure_msg $"${prog} startup"
+        echo
+        return $retval
+    fi
+
+    <% if not EZBake::Config[:redhat][:post_start_action].empty? -%>
+    if [ "$retval" = 0 ]; then
+        <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
+        <%= action %>
+        <% end -%>
+    fi
+    <% end -%>
+
+    # if the pid file exists, with the PID in it (non-zero size)
+    if [ -s "${PIDFILE}" ]; then
+        log_success_msg $"${prog} startup"
+        echo
+        touch "${lockfile}"
+        return 0
+    else
+        log_failure_msg $"${prog} startup"
+        echo
+        return 1
+    fi
 }
 
 stop() {

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -83,6 +83,7 @@ start() {
 
     # startproc will change users, so make sure that user has permission
     # to access the present working directory.
+    cd "${INSTALL_DIR}"
     startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" "/opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1"
     rc_status -v
     retval=$?

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -150,11 +150,11 @@ reload() {
     retval=$?
 
     if [ "$retval" = 0 ]; then
-        log_success_msg $"${prog} stopped"
+        log_success_msg $"${prog} reloaded"
         echo
         return 0
     else
-        log_failure_msg $"${prog} could not be stopped, check ${LOGFILE}"
+        log_failure_msg $"${prog} could not be reloaded, check ${LOGFILE}"
         echo
         return 1
     fi

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -43,7 +43,6 @@ config=$CONFIG
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 JARFILE="<%= EZBake::Config[:uberjar_name] %>"
 JAVA_ARGS="${JAVA_ARGS} -cp ${INSTALL_DIR}/${JARFILE} clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b ${BOOTSTRAP_CONFIG}"
-EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile="/var/lock/subsys/${prog}"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 LOGFILE="/var/log/puppetlabs/${realname}/${realname}.log"

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -75,7 +75,7 @@ start() {
     <%= action %>
     <% end -%>
 
-    /opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1
+    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" "/opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1"
     rc_status -v
     retval=$?
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -62,72 +62,9 @@ print_service_pid() {
 }
 
 start() {
-    local service_pid
-    [ -x "${JAVA_BIN}" ] || exit 5
-    [ -e "${config}" ] || exit 6
-    echo -n $"Starting ${prog}: "
-
-    <% if EZBake::Config[:open_file_limit] -%>
-    [ -n "$OPEN_FILE_LIMIT" ] && ulimit -n $OPEN_FILE_LIMIT
-    <% end -%>
-
-    <% EZBake::Config[:redhat][:pre_start_action].each do |action| -%>
-    <%= action %>
-    <% end -%>
-
-    # startproc creates logfiles but doesn't set ownership correctly for new
-    # files. Let's always do this in case the file ownership is wrong.
-    touch "${LOGFILE}"
-    chown $USER:$USER "${LOGFILE}"
-
-    export HOME="$(getent passwd ${USER} | cut -d':' -f6)"
-    # startproc will change users, so make sure that user has permission
-    # to access the present working directory.
-    cd "${INSTALL_DIR}"
-    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\"" -Djava.security.egd=/dev/urandom ${JAVA_ARGS}
-    rc_status -v
+    /opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
     retval=$?
-
-    # NOTE: retval holds the return value of `startproc`, not the process
-    # started by `startproc`.
-
-    # If rc_status didn't succeed, bail out early without bothering to poll
-    # waiting for the application or doing work that assumes a launching state
-    if [ "$retval" != 0 ]; then
-        log_failure_msg $"${prog} startup"
-        echo
-        return $retval
-    fi
-
-    service_pid="$(print_service_pid)"
-    echo -n "${service_pid}" > "${PIDFILE}"
-
-    <% if not EZBake::Config[:redhat][:post_start_action].empty? -%>
-    if [ "$retval" = 0 ]; then
-        <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
-        <%= action %>
-        <% end -%>
-    fi
-    <% end -%>
-
-    # Wait for the application to become available
-    if ! wait_for_app "${service_pid}" "$START_TIMEOUT"; then
-        log_failure_msg $"${prog} startup"
-        echo
-        return 1
-    fi
-
-    # if the pid file exists, with the PID in it (non-zero size)
-    if [ -s "${PIDFILE}" ]; then
-        log_success_msg $"${prog} startup"
-        echo
-        touch "${lockfile}"
-        return 0
-    else
-        log_failure_msg $"${prog} startup"
-        echo
-        return 1
-    fi
+    return $retval
 }
 
 stop() {
@@ -166,6 +103,12 @@ sl_status() {
     rc_status -v
 }
 
+reload() {
+    echo -n $"Reloading ${prog}:"
+    /opt/puppetlabs/server/apps/${realname}/bin/${realname} reload
+    rc_status -v
+}
+
 
 case "$1" in
     start)
@@ -183,11 +126,14 @@ case "$1" in
         sl_status_q || exit 0
         restart
         ;;
+    reload|force-reload)
+        reload
+        ;;
     status)
         sl_status
         ;;
     *)
-        echo $"Usage: ${0} {start|stop|restart|condrestart|try-restart|status}"
+        echo $"Usage: ${0} {start|stop|restart|condrestart|try-restart|reload|force-reload|status}"
         exit 2
 esac
 exit $?


### PR DESCRIPTION
Previously, system init scripts would daemonize a java process and then use a post-start command to poll for the port to open with netstat. This PR includes the new start script which will both daemonize a java process and poll for the service status using a restart-file implemented in [TK-345](https://github.com/puppetlabs/trapperkeeper/pull/248). The service scripts have been changed to call on this new `start` subcommand. 