### PR TITLE
(SERVER-366) Add boolean to disable logrotate

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ configuration necessary.
     :group "puppet"
     :start-timeout "120"
     :build-type "foss"
-    :java-args "-Xms2g -Xmx2g -XX:MaxPermSize=256m"}}}
+    :java-args "-Xms2g -Xmx2g -XX:MaxPermSize=256m"
+    :logrotate-enabled true}}}
 
 ```
 

--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -43,5 +43,6 @@ module EZBake
                             "{{package}}" => "{{version}}",
                           {{/replaces-pkgs}}
                           },
+      :logrotate_enabled => {{{logrotate-enabled}}},
   }
 end

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/rules.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/rules.erb
@@ -20,6 +20,7 @@ export EZ_VERBOSE=1
 
 install/<%= EZBake::Config[:project] %>::
 	bash install.sh install_deb
+<% if EZBake::Config[:logrotate_enabled]-%>
 	if [[ ${DIST} == debian ]] ; then \
 		if [[ $$(echo "${RELEASE}>=7" | bc -l) -eq 1 || ${RELEASE} == testing || ${RELEASE} == unstable ]] ; then \
 			bash install.sh logrotate ; \
@@ -33,6 +34,7 @@ install/<%= EZBake::Config[:project] %>::
 			bash install.sh logrotate_legacy ; \
 		fi ; \
 	fi
+<% end -%>
 
 <% unless EZBake::Config[:terminus_info].empty? -%>
 install/<%= EZBake::Config[:project] %>-termini::

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -98,11 +98,13 @@ env EZ_VERBOSE=1 DESTDIR=%{buildroot} prefix=%{_prefix} confdir=%{_sysconfdir} b
 env EZ_VERBOSE=1 DESTDIR=%{buildroot} prefix=%{_prefix} confdir=%{_sysconfdir} bindir=%{_bindir} rundir=%{_rundir}/<%= EZBake::Config[:project] %> defaultsdir=%{_sysconfdir}/sysconfig initdir=%{_initrddir} bash install.sh sysv_init_redhat
 %endif
 
+<% if EZBake::Config[:logrotate_enabled]-%>
 %if 0%{?fedora} >= 16 || 0%{?rhel} >= 7 || 0%{?sles_version} >= 12
 env EZ_VERBOSE=1 DESTDIR=%{buildroot} confdir=%{_sysconfdir} bash install.sh logrotate
 %else
 env EZ_VERBOSE=1 DESTDIR=%{buildroot} confdir=%{_sysconfdir} bash install.sh logrotate_legacy
 %endif
+<% end -%>
 
 <% unless EZBake::Config[:terminus_info].empty? -%>
 env EZ_VERBOSE=1 DESTDIR=%{buildroot} rubylibdir=%{rubylibdir} prefix=%{_prefix} bash install.sh termini
@@ -192,7 +194,9 @@ fi
 %endif
 %config(noreplace) %{_sysconfdir}/%{name}
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
+<% if EZBake::Config[:logrotate_enabled]-%>
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
+<% end -%>
 <% if ! EZBake::Config[:cli_app_files].empty? -%>
 %{_bindir}/<%= EZBake::Config[:real_name] %>
 <% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/rules.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/rules.erb
@@ -19,6 +19,7 @@ export EZ_VERBOSE=1
 
 install/<%= EZBake::Config[:project] %>::
 	bash install.sh install_deb
+<% if EZBake::Config[:logrotate_enabled]-%>
 	if [[ ${DIST} == debian ]] ; then \
 		if [[ $$(echo "${RELEASE}>=7" | bc -l) -eq 1 || ${RELEASE} == testing || ${RELEASE} == unstable ]] ; then \
 			bash install.sh logrotate ; \
@@ -32,6 +33,7 @@ install/<%= EZBake::Config[:project] %>::
 			bash install.sh logrotate_legacy ; \
 		fi ; \
 	fi
+<% end -%>
 
 <% unless EZBake::Config[:terminus_info].empty?  -%>
 install/<%= EZBake::Config[:project] %>-termini::

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -152,11 +152,13 @@ env EZ_VERBOSE=1 DESTDIR=%{buildroot} prefix=%{_prefix} confdir=%{_sysconfdir} b
 %endif
 %endif
 
+<% if EZBake::Config[:logrotate_enabled]-%>
 %if 0%{?fedora} >= 16 || 0%{?rhel} >= 7 || 0%{?sles_version} >= 12
 env EZ_VERBOSE=1 DESTDIR=%{buildroot} confdir=%{_real_sysconfdir} bash install.sh logrotate
 %else
 env EZ_VERBOSE=1 DESTDIR=%{buildroot} confdir=%{_real_sysconfdir} bash install.sh logrotate_legacy
 %endif
+<% end -%>
 
 <% unless EZBake::Config[:terminus_info].empty? -%>
 env EZ_VERBOSE=1 DESTDIR=%{buildroot} rubylibdir=%{rubylibdir} prefix=%{_prefix} bash install.sh termini
@@ -263,7 +265,9 @@ fi
 %endif
 %config(noreplace) %{_sysconfdir}/%{realname}
 %config(noreplace) %{_real_sysconfdir}/sysconfig/%{name}
+<% if EZBake::Config[:logrotate_enabled]-%>
 %config(noreplace) %{_real_sysconfdir}/logrotate.d/%{name}
+<% end -%>
 <% if ! EZBake::Config[:cli_app_files].empty? -%>
 %{_bindir}/<%= EZBake::Config[:real_name] %>
 <% end -%>

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -408,7 +408,9 @@ Dependency tree:
                                                           :main-namespace
                                                           "puppetlabs.trapperkeeper.main")
          :java-args                 (get-local-ezbake-var lein-project :java-args
-                                                          "-Xmx192m")}))))
+                                                          "-Xmx192m")
+         :logrotate-enabled         (get-local-ezbake-var lein-project :logrotate-enabled
+                                                          true)}))))
 
 (defn generate-project-data-yaml
   [lein-project build-target]


### PR DESCRIPTION
This commit adds a new boolean ezbake setting to disable logrotate in a project

SERVER-366 covers work to limit the amount of disk space puppetserver will use for its logs. We decided to accomplish that by utilizing the built in features of the logback library. Logback will
* Do daily rotating of logs
* Rotate the logs out once they reach a certain size
* Limit the total size of all the puppetserver log file

Logrotate is no longer needed, so we needed a way to disable logrotate in ezbake. The change in this PR is backwards compatible, as it defaults to turning logrotate on.