### PR TITLE
(MAINT) Update changelog for 0.2.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.13 - 2016-08-31
+ * Feature: Add `:logrotate-enabled` setting to allow disabling of logrotate.
+   Enabled by default.
+
+ Note: While technically a minor feature release, this is going to be a Z
+ release to avoid branch renaming hassles.
+
 ## 0.2.12 - 2016-06-13
  * Backport changes to avoid setting -XX:+HeapDumpOnOutOfMemoryError by default
 


### PR DESCRIPTION
Changlog:
* Add `:logrotate-enabled` setting to allow disabling of logrotate. Enabled
  by default.

Note: While technically a minor feature release, this is going to be a Z
release to avoid branch renaming hassles.