### PR TITLE
(EZ-95) merge 0.2.x to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ configuration necessary.
     :group "puppet"
     :start-timeout "120"
     :build-type "foss"
-    :java-args "-Xms2g -Xmx2g -XX:MaxPermSize=256m"}}}
+    :java-args "-Xms2g -Xmx2g -XX:MaxPermSize=256m"
+    :logrotate-enabled true}}}
 
 ```
 

--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -44,6 +44,7 @@ module EZBake
                             "{{package}}" => "{{version}}",
                           {{/replaces-pkgs}}
                           },
-      :bootstrap_source => '{{{bootstrap-source}}}'
+      :bootstrap_source => '{{{bootstrap-source}}}',
+      :logrotate_enabled => {{{logrotate-enabled}}}
   }
 end

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/rules.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/rules.erb
@@ -19,6 +19,7 @@ export EZ_VERBOSE=1
 
 install/<%= EZBake::Config[:project] %>::
 	bash install.sh install_deb
+<% if EZBake::Config[:logrotate_enabled]-%>
 	if [[ ${DIST} == debian ]] ; then \
 		if [[ $$(echo "${RELEASE}>=7" | bc -l) -eq 1 || ${RELEASE} == testing || ${RELEASE} == unstable ]] ; then \
 			bash install.sh logrotate ; \
@@ -32,6 +33,7 @@ install/<%= EZBake::Config[:project] %>::
 			bash install.sh logrotate_legacy ; \
 		fi ; \
 	fi
+<% end -%>
 	if $$(echo "${SYSV_CODENAMES}" | grep -q ${CODENAME}) ; then \
 		bash install.sh sysv_init_deb ; \
 	else \

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -141,11 +141,13 @@ env EZ_VERBOSE=1 DESTDIR=%{buildroot} prefix=%{_prefix} app_prefix=%{_app_prefix
 env EZ_VERBOSE=1 DESTDIR=%{buildroot} prefix=%{_prefix} app_prefix=%{_app_prefix} app_data=%{_app_data} confdir=%{_sysconfdir} bindir=%{_app_bindir} symbindir=%{_sym_bindir} rundir=%{_app_rundir} defaultsdir=%{_sysconfdir}/sysconfig initdir=%{_initrddir} bash install.sh sysv_init_redhat
 %endif
 
+<% if EZBake::Config[:logrotate_enabled]-%>
 %if 0%{?fedora} >= 16 || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1315
 env EZ_VERBOSE=1 DESTDIR=%{buildroot} confdir=%{_sysconfdir} bash install.sh logrotate
 %else
 env EZ_VERBOSE=1 DESTDIR=%{buildroot} confdir=%{_sysconfdir} bash install.sh logrotate_legacy
 %endif
+<% end -%>
 
 <% unless EZBake::Config[:terminus_info].empty? -%>
 env EZ_VERBOSE=1 DESTDIR=%{buildroot} rubylibdir=%{rubylibdir} prefix=%{_prefix} bash install.sh termini
@@ -247,7 +249,9 @@ fi
 %endif
 %config(noreplace) %{_sysconfdir}/puppetlabs/%{realname}
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
+<% if EZBake::Config[:logrotate_enabled]-%>
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
+<% end -%>
 <% if ! EZBake::Config[:cli_app_files].empty? -%>
 %{_app_bindir}/<%= EZBake::Config[:real_name] %>
 %{_sym_bindir}/<%= EZBake::Config[:real_name] %>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/rules.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/rules.erb
@@ -19,6 +19,7 @@ export EZ_VERBOSE=1
 
 install/<%= EZBake::Config[:project] %>::
 	bash install.sh install_deb
+<% if EZBake::Config[:logrotate_enabled]-%>
 	if [[ ${DIST} == debian ]] ; then \
 		if [[ $$(echo "${RELEASE}>=7" | bc -l) -eq 1 || ${RELEASE} == testing || ${RELEASE} == unstable ]] ; then \
 			bash install.sh logrotate ; \
@@ -32,6 +33,7 @@ install/<%= EZBake::Config[:project] %>::
 			bash install.sh logrotate_legacy ; \
 		fi ; \
 	fi
+<% end -%>
 	if $$(echo "${SYSV_CODENAMES}" | grep -q ${CODENAME}) ; then \
 		bash install.sh sysv_init_deb ; \
 	else \

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -148,11 +148,13 @@ env EZ_VERBOSE=1 DESTDIR=%{buildroot} prefix=%{_prefix} app_prefix=%{_app_prefix
 %endif
 %endif
 
+<% if EZBake::Config[:logrotate_enabled]-%>
 %if 0%{?fedora} >= 16 || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1315
 env EZ_VERBOSE=1 DESTDIR=%{buildroot} confdir=%{_sysconfdir} bash install.sh logrotate
 %else
 env EZ_VERBOSE=1 DESTDIR=%{buildroot} confdir=%{_sysconfdir} bash install.sh logrotate_legacy
 %endif
+<% end -%>
 
 <% unless EZBake::Config[:terminus_info].empty? -%>
 env EZ_VERBOSE=1 DESTDIR=%{buildroot} rubylibdir=%{rubylibdir} prefix=%{_prefix} bash install.sh termini
@@ -254,7 +256,9 @@ fi
 %endif
 %config(noreplace) %{_sysconfdir}/puppetlabs/%{realname}
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
+<% if EZBake::Config[:logrotate_enabled]-%>
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
+<% end -%>
 <% if ! EZBake::Config[:cli_app_files].empty? -%>
 %{_app_bindir}/<%= EZBake::Config[:real_name] %>
 %{_sym_bindir}/<%= EZBake::Config[:real_name] %>

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -433,7 +433,9 @@ Dependency tree:
      :bootstrap-source          (name (validate-bootstrap-source
                                        (get-local-ezbake-var lein-project
                                                              :bootstrap-source
-                                                             :bootstrap-cfg)))}))
+                                                             :bootstrap-cfg)))
+     :logrotate-enabled         (get-local-ezbake-var lein-project :logrotate-enabled
+                                                      true)}))
 
 ;; TODO: this is wonky; we're basically doing some templating here and it
 ;; might make more sense to use an actual template for it.  However, I'm a bit


### PR DESCRIPTION
This commit merges the changes from server-366 from 0.2.x to stable

SERVER-366 covers work to limit the amount of disk space puppetserver will use
for its logs.

----

**Note:** We accidentally merged this to master earlier. This is harmless as we would have needed to merge it up to master eventually anyways. 