### PR TITLE
(EZ-96) Exit with appropriate codes for start/stop in Debian init script

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -146,18 +146,22 @@ case "$1" in
     start)
         [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
         do_start
-        case "$?" in
+        RETVAL="$?"
+        case "$RETVAL" in
             0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
             2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
         esac
+        exit "$RETVAL"
         ;;
     stop)
         [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
         do_stop
-        case "$?" in
+        RETVAL="$?"
+        case "$RETVAL" in
             0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
             2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
         esac
+        exit "$RETVAL"
         ;;
     status)
         get_status

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -147,18 +147,22 @@ case "$1" in
     start)
         [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
         do_start
-        case "$?" in
+        RETVAL="$?"
+        case "$RETVAL" in
             0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
             2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
         esac
+        exit "$RETVAL"
         ;;
     stop)
         [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
         do_stop
-        case "$?" in
+        RETVAL="$?"
+        case "$RETVAL" in
             0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
             2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
         esac
+        exit "$RETVAL"
         ;;
     status)
         get_status


### PR DESCRIPTION
This commit fixes a bug introduced by EZ-70 where the start and stop
actions in Debian init scripts would errantly return a 1 (failure) exit
code when the start/stop succeeded rather than returning a 0.