### PR TITLE
(EZ-97) Start / reload commands should error immediately after Java process dies

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -178,7 +178,9 @@ case "$1" in
     force-reload|reload)
         [ "$VERBOSE" != no ] && log_daemon_msg "Reloading $DESC" "$NAME"
         do_reload
-        log_end_msg $?
+        RETVAL="$?"
+        [ "$VERBOSE" != no ] && log_end_msg $RETVAL
+        exit "$RETVAL"
         ;;
     *)
         echo "Usage: $SCRIPTNAME {start|stop|status|condrestart|try-restart|restart|force-reload|reload}" >&2

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -148,8 +148,8 @@ case "$1" in
         do_start
         RETVAL="$?"
         case "$RETVAL" in
-            0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-            2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+            0) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+            1|2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
         esac
         exit "$RETVAL"
         ;;

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
@@ -23,7 +23,7 @@ if [ -r "$restartfile" ];  then
         cur=$(head -n 1 "$restartfile")
 
         ((timeout--))
-        if [ "$timeout" = 0 ]; then
+        if [ $timeout -eq 0 ]; then
             echo "Reload timed out after <%= EZBake::Config[:start_timeout].to_i / 10 %> seconds"
             exit 1
         fi

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
@@ -1,16 +1,24 @@
 #!/usr/bin/env bash
-set -e
+set +e
 
 restartfile=<%= EZBake::Config[:restart_file] %>
 timeout=<%= EZBake::Config[:start_timeout] %>
 
 if [ -r "$restartfile" ];  then
     pid=$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)
-    kill -HUP $pid
+    kill -HUP $pid >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Service not running so cannot be reloaded" 1>&2
+        exit 1
+    fi
     cur=$(head -n 1 "$restartfile")
     initial=$cur
     while [ "$cur" == "$initial" ] ;do
         kill -0 $pid >/dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            echo "Process $pid exited before reload had completed" 1>&2
+            exit 1
+        fi
         sleep 0.1
         cur=$(head -n 1 "$restartfile")
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
@@ -10,7 +10,7 @@ if [ -r "$restartfile" ];  then
     cur=$(head -n 1 "$restartfile")
     initial=$cur
     while [ "$cur" == "$initial" ] ;do
-        kill -0 $pid 2>/dev/null
+        kill -0 $pid >/dev/null 2>&1
         sleep 0.1
         cur=$(head -n 1 "$restartfile")
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
@@ -5,10 +5,12 @@ restartfile=<%= EZBake::Config[:restart_file] %>
 timeout=<%= EZBake::Config[:start_timeout] %>
 
 if [ -r "$restartfile" ];  then
-    kill -HUP $(pgrep -f <%= EZBake::Config[:uberjar_name] %>)
+    pid=$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)
+    kill -HUP $pid
     cur=$(head -n 1 "$restartfile")
     initial=$cur
     while [ "$cur" == "$initial" ] ;do
+        kill -0 $pid 2>/dev/null
         sleep 0.1
         cur=$(head -n 1 "$restartfile")
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -7,6 +7,8 @@ dir=$(dirname "$restartfile")
 realname="<%= EZBake::Config[:real_name] %>"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 
+rm -f "$PIDFILE"
+
 if [ ! -e "$restartfile" ]; then
     mkdir -p "$dir"
     echo -n "0" > "$restartfile"

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -1,11 +1,56 @@
 #!/usr/bin/env bash
+pid=$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)
+
 set -e
 
 restartfile=<%= EZBake::Config[:restart_file] %>
-timeout=<%= EZBake::Config[:start_timeout] %>
+start_timeout=<%= EZBake::Config[:start_timeout] %>
+stop_timeout=60
 dir=$(dirname "$restartfile")
 realname="<%= EZBake::Config[:real_name] %>"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
+
+write_pid_file() {
+    if [ ! -d "/var/run/puppetlabs/${realname}" ]; then
+        mkdir -p /var/run/puppetlabs/${realname}
+        chown -R $USER:$GROUP /var/run/puppetlabs/${realname}
+    fi
+    echo $1 > $PIDFILE
+}
+
+terminate_java_process() {
+    set +e
+
+    echo "Startup script was terminated before completion" 1>&2
+    kill -TERM $pid >/dev/null 2>&1
+    sleep 0.1
+
+    timeout=$stop_timeout
+    kill -0 $pid >/dev/null 2>&1
+    while [ $? == 0 ] && [ "$timeout" != 0 ]; do
+        sleep 1
+        ((timeout--))
+        kill -0 $pid >/dev/null 2>&1
+    done
+
+    if [ "$timeout" = 0 ]; then
+        echo "Java process $pid not terminated gracefully after $stop_timeout seconds" 1>&2
+        kill -KILL $pid >/dev/null 2>&1
+        sleep 1
+        if [ $? = 0 ]; then
+            echo "Java process $pid not killed after SIGKILL" 1>&2
+        fi
+    fi
+
+    rm -f "$PIDFILE"
+    set -e
+    exit 1
+}
+
+if [ ! -z $pid ]; then
+    write_pid_file $pid
+    exit 0
+fi
 
 rm -f "$PIDFILE"
 
@@ -20,25 +65,32 @@ fi
 ${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=/dev/urandom -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> clojure.main -m <%= EZBake::Config[:main_namespace] %> --config "${CONFIG}" -b "${BOOTSTRAP_CONFIG}" &
 
 pid=$!
+trap terminate_java_process SIGHUP SIGINT SIGTERM
+write_pid_file $pid
+
 cur=$(head -n 1 "$restartfile")
 initial=$cur
 
+timeout=$start_timeout
+set +e
 while [ "$cur" == "$initial" ] ;do
-    kill -0 $pid 2>/dev/null
+    kill -0 $pid >/dev/null 2>&1
+    if [ $? != 0 ]; then
+      rm -f "$PIDFILE"
+      echo "Background process $pid exited before start had completed" 1>&2
+      exit 1
+    fi
+
     sleep 1
     cur=$(head -n 1 "$restartfile")
 
     ((timeout--))
     if [ "$timeout" = 0 ]; then
-        echo "Startup timed out after <%= EZBake::Config[:start_timeout] %> seconds" 1>&2
+        echo "Startup timed out after $start_timeout seconds" 1>&2
         exit 1
     fi
 done
+set -e
 
-if [ ! -d  "/var/run/puppetlabs/${realname}" ] ; then
-    mkdir -p /var/run/puppetlabs/${realname}
-    chown -R $USER:$GROUP /var/run/puppetlabs/${realname}
-fi
-echo $pid > $PIDFILE
-
+write_pid_file $pid
 exit 0

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -35,6 +35,7 @@ terminate_java_process() {
         echo "Java process $pid not terminated gracefully after $stop_timeout seconds" 1>&2
         kill -KILL $pid >/dev/null 2>&1
         sleep 1
+        kill -0 $pid >/dev/null 2>&1
         if [ $? -eq 0 ]; then
             echo "Java process $pid not killed after SIGKILL" 1>&2
         fi

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -7,15 +7,6 @@ dir=$(dirname "$restartfile")
 realname="<%= EZBake::Config[:real_name] %>"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 
-find_my_pid() {
-    pid=`pgrep -f <%= EZBake::Config[:uberjar_name] %>`
-    if [ ! -d  "/var/run/puppetlabs/${realname}" ] ; then
-        mkdir -p /var/run/puppetlabs/${realname}
-        chown -R $USER:$GROUP /var/run/puppetlabs/${realname}
-    fi
-    echo $pid > $PIDFILE
-}
-
 if [ ! -e "$restartfile" ]; then
     mkdir -p "$dir"
     echo -n "0" > "$restartfile"
@@ -26,10 +17,12 @@ fi
 
 ${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=/dev/urandom -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> clojure.main -m <%= EZBake::Config[:main_namespace] %> --config "${CONFIG}" -b "${BOOTSTRAP_CONFIG}" &
 
+pid=$!
 cur=$(head -n 1 "$restartfile")
 initial=$cur
 
 while [ "$cur" == "$initial" ] ;do
+    kill -0 $pid 2>/dev/null
     sleep 1
     cur=$(head -n 1 "$restartfile")
 
@@ -40,5 +33,10 @@ while [ "$cur" == "$initial" ] ;do
     fi
 done
 
-find_my_pid
+if [ ! -d  "/var/run/puppetlabs/${realname}" ] ; then
+    mkdir -p /var/run/puppetlabs/${realname}
+    chown -R $USER:$GROUP /var/run/puppetlabs/${realname}
+fi
+echo $pid > $PIDFILE
+
 exit 0

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-pid=$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)
+set +e
 
-set -e
+pid=$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)
 
 restartfile=<%= EZBake::Config[:restart_file] %>
 start_timeout=<%= EZBake::Config[:start_timeout] %>
@@ -19,8 +19,6 @@ write_pid_file() {
 }
 
 terminate_java_process() {
-    set +e
-
     echo "Startup script was terminated before completion" 1>&2
     kill -TERM $pid >/dev/null 2>&1
     sleep 0.1
@@ -43,7 +41,6 @@ terminate_java_process() {
     fi
 
     rm -f "$PIDFILE"
-    set -e
     exit 1
 }
 
@@ -72,7 +69,6 @@ cur=$(head -n 1 "$restartfile")
 initial=$cur
 
 timeout=$start_timeout
-set +e
 while [ "$cur" == "$initial" ] ;do
     kill -0 $pid >/dev/null 2>&1
     if [ $? != 0 ]; then
@@ -90,7 +86,6 @@ while [ "$cur" == "$initial" ] ;do
         exit 1
     fi
 done
-set -e
 
 write_pid_file $pid
 exit 0

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -61,6 +61,7 @@ fi
 
 ${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=/dev/urandom -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> clojure.main -m <%= EZBake::Config[:main_namespace] %> --config "${CONFIG}" -b "${BOOTSTRAP_CONFIG}" &
 
+# $! is the process id of the last backgrounded process, the Java process above.
 pid=$!
 trap terminate_java_process SIGHUP SIGINT SIGTERM
 write_pid_file $pid

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -25,17 +25,17 @@ terminate_java_process() {
 
     timeout=$stop_timeout
     kill -0 $pid >/dev/null 2>&1
-    while [ $? == 0 ] && [ "$timeout" != 0 ]; do
+    while [ $? -eq 0 ] && [ $timeout -ne 0 ]; do
         sleep 1
         ((timeout--))
         kill -0 $pid >/dev/null 2>&1
     done
 
-    if [ "$timeout" = 0 ]; then
+    if [ $timeout -eq 0 ]; then
         echo "Java process $pid not terminated gracefully after $stop_timeout seconds" 1>&2
         kill -KILL $pid >/dev/null 2>&1
         sleep 1
-        if [ $? = 0 ]; then
+        if [ $? -eq 0 ]; then
             echo "Java process $pid not killed after SIGKILL" 1>&2
         fi
     fi
@@ -71,7 +71,7 @@ initial=$cur
 timeout=$start_timeout
 while [ "$cur" == "$initial" ] ;do
     kill -0 $pid >/dev/null 2>&1
-    if [ $? != 0 ]; then
+    if [ $? -ne 0 ]; then
       rm -f "$PIDFILE"
       echo "Background process $pid exited before start had completed" 1>&2
       exit 1
@@ -81,7 +81,7 @@ while [ "$cur" == "$initial" ] ;do
     cur=$(head -n 1 "$restartfile")
 
     ((timeout--))
-    if [ "$timeout" = 0 ]; then
+    if [ $timeout -eq 0 ]; then
         echo "Startup timed out after $start_timeout seconds" 1>&2
         exit 1
     fi

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -149,8 +149,8 @@ case "$1" in
         do_start
         RETVAL="$?"
         case "$RETVAL" in
-            0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-            2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+            0) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+            1|2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
         esac
         exit "$RETVAL"
         ;;

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -179,7 +179,9 @@ case "$1" in
     force-reload|reload)
         [ "$VERBOSE" != no ] && log_daemon_msg "Reloading $DESC" "$NAME"
         do_reload
-        log_end_msg $?
+        RETVAL="$?"
+        [ "$VERBOSE" != no ] && log_end_msg $RETVAL
+        exit "$RETVAL"
         ;;
     *)
         echo "Usage: $SCRIPTNAME {start|stop|status|condrestart|try-restart|restart|force-reload|reload}" >&2


### PR DESCRIPTION
This PR primarily handles terminating the "wait for" loops immediately if the Java process spawned by the start or reload commands dies.  Previously, the commands would wait for a full configured "timeout" to expire before terminating.  In the process of hooking this up, I found a few related bugs around start functionality which are addressed in this PR, including:

* If the start script is terminated - e.g., by systemctl under systemd - while still running, the associated Java process is now terminated as well.  Previously, the Java process could continue running, leaving the resulting service in an inconsistent state (depending upon timing) from the service framework's perspective.

* Handle an exit code of "1" under Debian init as a failure instead of as a success.  Previously, the result of a start attempt when the service failed to start was treated as "success".

* Make the Debian init script's use of the VERBOSE flag for reload actions consistent with that used for other actions.

* Some cleanup around ensuring that the service pidfile is removed when the Java process fails to be started, helping make service frameworks more consistently report "failure" when the service isn't started properly.