### PR TITLE
(EZ-88) Add per-project build dependencies

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -23,6 +23,7 @@ module EZBake
                           },
       :debian         => {
                           :additional_dependencies => [{{{debian-deps}}}],
+                          :additional_build_dependencies => [{{{debian-build-deps}}}],
                           :additional_preinst => [{{{debian-preinst}}}],
                           :additional_postinst => [{{{debian-postinst}}}],
                           :additional_install => [{{{debian-install}}}],
@@ -31,6 +32,7 @@ module EZBake
                           },
       :redhat         => {
                           :additional_dependencies => [{{{redhat-deps}}}],
+                          :additional_build_dependencies => [{{{redhat-build-deps}}}],
                           :additional_preinst => [{{{redhat-preinst}}}],
                           :additional_postinst => [{{{redhat-postinst}}}],
                           :additional_install => [{{{redhat-install}}}],

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/control.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/control.erb
@@ -2,7 +2,10 @@ Source: <%= EZBake::Config[:project] %>
 Section: utils
 Priority: optional
 Maintainer: Puppet Labs <info@puppetlabs.com>
-Build-Depends: debhelper (>= 7.0.0~), cdbs, bc, mawk, lsb-release, ruby | ruby-interpreter
+Build-Depends: debhelper (>= 7.0.0~), cdbs, bc, mawk, lsb-release, ruby | ruby-interpreter<%=
+    if !EZBake::Config[:debian][:additional_build_dependencies].empty?
+      ", " + EZBake::Config[:debian][:additional_build_dependencies].join(", ")
+    end %>
 Standards-Version: 3.9.1
 Homepage: http://puppetlabs.com
 

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -104,6 +104,9 @@ Requires:         %{open_jdk}
 # net-tools is required for netstat usage in service unit file
 # See: https://tickets.puppetlabs.com/browse/SERVER-338
 Requires:         net-tools
+<% EZBake::Config[:redhat][:additional_build_dependencies].each do |dep| %>
+BuildRequires:    <%= dep %>
+<% end %>
 <% EZBake::Config[:redhat][:additional_dependencies].each do |dep| %>
 Requires:         <%= dep %>
 <% end %>

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -262,7 +262,7 @@ fi
 %{_sym_bindir}/<%= bin_file.sub(%r{^ext/bin/}, "") %>
 %{_ux_bindir}/<%= bin_file.sub(%r{^ext/bin/}, "") %>
 <% end -%>
-%dir %attr(0770, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_data}
+%attr(-, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_data}
 %dir %attr(0755, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_rundir}
 
 <% unless EZBake::Config[:terminus_info].empty? -%>

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -132,7 +132,7 @@ function task_install_source_deb_systemd {
 # Debian packaging during the 'install' phases.
 function task_install {
     install -d -m 0755 "${DESTDIR}${app_prefix}"
-    install -d -m 0755 "${DESTDIR}${app_data}"
+    install -d -m 0770 "${DESTDIR}${app_data}"
     install -m 0644 <%= EZBake::Config[:uberjar_name] %> "${DESTDIR}${app_prefix}"
     install -m 0755 ext/ezbake-functions.sh "${DESTDIR}${app_prefix}"
     install -m 0644 ext/ezbake.manifest "${DESTDIR}${app_prefix}"

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/control.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/control.erb
@@ -2,7 +2,10 @@ Source: <%= EZBake::Config[:project] %>
 Section: utils
 Priority: optional
 Maintainer: Puppet Labs <info@puppetlabs.com>
-Build-Depends: debhelper (>= 7.0.0~), cdbs, bc, mawk, lsb-release, puppet-agent
+Build-Depends: debhelper (>= 7.0.0~), cdbs, bc, mawk, lsb-release, puppet-agent<%=
+    if !EZBake::Config[:debian][:additional_build_dependencies].empty?
+      ", " + EZBake::Config[:debian][:additional_build_dependencies].join(", ")
+    end %>
 Standards-Version: 3.9.1
 Homepage: http://puppetlabs.com
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -269,7 +269,7 @@ fi
 %{_sym_bindir}/<%= bin_file.sub(%r{^ext/bin/}, "") %>
 %{_ux_bindir}/<%= bin_file.sub(%r{^ext/bin/}, "") %>
 <% end -%>
-%dir %attr(0770, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_data}
+%attr(-, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_data}
 %dir %attr(0755, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_rundir}
 
 <% unless EZBake::Config[:terminus_info].empty? -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -103,6 +103,9 @@ Requires:         pe-puppet-enterprise-release
 # net-tools is required for netstat usage in service unit file
 # See: https://tickets.puppetlabs.com/browse/SERVER-338
 Requires:         net-tools
+<% EZBake::Config[:redhat][:additional_build_dependencies].each do |dep| %>
+BuildRequires:    <%= dep %>
+<% end %>
 <% EZBake::Config[:redhat][:additional_dependencies].each do |dep| %>
 Requires:         <%= dep %>
 <% end %>

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -409,6 +409,7 @@ Dependency tree:
      :create-dirs               (quoted-list (get-local-ezbake-var lein-project
                                                                    :create-dirs []))
      :debian-deps               (get-quoted-ezbake-values :debian :dependencies)
+     :debian-build-deps         (get-quoted-ezbake-values :debian :build-dependencies)
      :debian-preinst            (get-quoted-ezbake-values :debian :preinst)
      :debian-prerm              (get-quoted-ezbake-values :debian :prerm)
      :debian-postinst           (get-quoted-ezbake-values :debian :postinst)
@@ -416,6 +417,7 @@ Dependency tree:
      :debian-pre-start-action   (get-quoted-ezbake-values :debian :pre-start-action)
      :debian-post-start-action  (get-quoted-ezbake-values :debian :post-start-action)
      :redhat-deps               (get-quoted-ezbake-values :redhat :dependencies)
+     :redhat-build-deps         (get-quoted-ezbake-values :redhat :build-dependencies)
      :redhat-preinst            (get-quoted-ezbake-values :redhat :preinst)
      :redhat-postinst           (get-quoted-ezbake-values :redhat :postinst)
      :redhat-install            (get-quoted-ezbake-values :redhat :install)


### PR DESCRIPTION
This adds per-project build dependencies to ezbake, allowing projects to declare build deps in the same was as runtime deps for packaging.

This also adds the contents of the project data directory to packaging, instead of just packaging the top-level data directory. This allows package builds to install files there and have them picked up by packaging.