### PR TITLE
(EZ-88) Add pe-java as a build dependency

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/control.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/control.erb
@@ -2,7 +2,7 @@ Source: <%= EZBake::Config[:project] %>
 Section: utils
 Priority: optional
 Maintainer: Puppet Labs <info@puppetlabs.com>
-Build-Depends: debhelper (>= 7.0.0~), cdbs, bc, mawk, lsb-release, ruby | ruby-interpreter
+Build-Depends: debhelper (>= 7.0.0~), cdbs, bc, mawk, lsb-release, ruby | ruby-interpreter, openjdk-7-jre-headless | openjdk-8-jre-headless
 Standards-Version: 3.9.1
 Homepage: http://puppetlabs.com
 

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -100,6 +100,7 @@ Requires(postun): systemd
 %{?systemd_requires}
 %endif
 
+BuildRequires:    %{open_jdk}
 Requires:         %{open_jdk}
 # net-tools is required for netstat usage in service unit file
 # See: https://tickets.puppetlabs.com/browse/SERVER-338

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -262,7 +262,7 @@ fi
 %{_sym_bindir}/<%= bin_file.sub(%r{^ext/bin/}, "") %>
 %{_ux_bindir}/<%= bin_file.sub(%r{^ext/bin/}, "") %>
 <% end -%>
-%dir %attr(0770, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_data}
+%attr(-, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_data}
 %dir %attr(0755, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_rundir}
 
 <% unless EZBake::Config[:terminus_info].empty? -%>

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -132,7 +132,7 @@ function task_install_source_deb_systemd {
 # Debian packaging during the 'install' phases.
 function task_install {
     install -d -m 0755 "${DESTDIR}${app_prefix}"
-    install -d -m 0755 "${DESTDIR}${app_data}"
+    install -d -m 0770 "${DESTDIR}${app_data}"
     install -m 0644 <%= EZBake::Config[:uberjar_name] %> "${DESTDIR}${app_prefix}"
     install -m 0755 ext/ezbake-functions.sh "${DESTDIR}${app_prefix}"
     install -m 0644 ext/ezbake.manifest "${DESTDIR}${app_prefix}"

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/control.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/control.erb
@@ -2,7 +2,7 @@ Source: <%= EZBake::Config[:project] %>
 Section: utils
 Priority: optional
 Maintainer: Puppet Labs <info@puppetlabs.com>
-Build-Depends: debhelper (>= 7.0.0~), cdbs, bc, mawk, lsb-release, puppet-agent
+Build-Depends: debhelper (>= 7.0.0~), cdbs, bc, mawk, lsb-release, puppet-agent, pe-java
 Standards-Version: 3.9.1
 Homepage: http://puppetlabs.com
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -269,7 +269,7 @@ fi
 %{_sym_bindir}/<%= bin_file.sub(%r{^ext/bin/}, "") %>
 %{_ux_bindir}/<%= bin_file.sub(%r{^ext/bin/}, "") %>
 <% end -%>
-%dir %attr(0770, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_data}
+%attr(-, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_data}
 %dir %attr(0755, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) %{_app_rundir}
 
 <% unless EZBake::Config[:terminus_info].empty? -%>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -98,6 +98,7 @@ Requires(postun): systemd
 %{?systemd_requires}
 %endif
 
+BuildRequires:    pe-java
 Requires:         pe-java
 Requires:         pe-puppet-enterprise-release
 # net-tools is required for netstat usage in service unit file


### PR DESCRIPTION
... and package app data dir contents if they exist.

This allows applications to install things to the data directory and have them packaged at build time. For example, the puppetserver package can include gems for the jruby environment in the data dir.