### PR TITLE
(EZ-99) Introduce TK stop script and call from service stop

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/control.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/control.erb
@@ -13,7 +13,8 @@ Package: <%= EZBake::Config[:project] %>
 Architecture: all
 # net-tools is required for netstat usage in service unit file
 # See: https://tickets.puppetlabs.com/browse/SERVER-338
-Depends: ${misc:Depends}, openjdk-7-jre-headless | openjdk-8-jre-headless, net-tools, adduser<%=
+# procps is required for pgrep, used in several of the init scripts
+Depends: ${misc:Depends}, openjdk-7-jre-headless | openjdk-8-jre-headless, net-tools, adduser, procps<%=
     if !EZBake::Config[:debian][:additional_dependencies].empty?
       ", " + EZBake::Config[:debian][:additional_dependencies].join(", ")
     end %>

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -63,7 +63,7 @@ do_start()
     <% end -%>
 
     start-stop-daemon --start --quiet --chuid $USER --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR \
-      --startas "/opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME}" -- start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1
+      --startas "${INSTALL_DIR}/bin/${REALNAME}" -- start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1
     retval=$?
 
     <% if not EZBake::Config[:debian][:post_start_action].empty? -%>
@@ -82,16 +82,7 @@ do_start()
 #
 do_stop()
 {
-    # Return
-    #   0 if daemon has been stopped or was already stopped
-    #   2 if daemon could not be stopped
-    #   other if a failure occurred
-    start-stop-daemon --stop --quiet --oknodo --retry=TERM/${SERVICE_STOP_RETRIES}/KILL/5 --pidfile $PIDFILE --exec $JAVA_BIN
-    RETVAL="$?"
-    [ "$RETVAL" = 2 ] && return 2
-    # Many daemons don't delete their pidfiles when they exit.
-    rm -f $PIDFILE
-    return "$RETVAL"
+    "${INSTALL_DIR}/bin/${REALNAME}" stop
 }
 
 #
@@ -118,27 +109,24 @@ get_status_q()
 do_restart()
 {
     do_stop
-    case "$?" in
-        0|1)
-            do_start
-            case "$?" in
-                0) log_end_msg 0 ;;
-                1) log_end_msg 1 ;; # Old process is still running
-                *) log_end_msg 1 ;; # Failed to start
-            esac
-            ;;
-        *)
-            # Failed to stop
-            log_end_msg 1
-            ;;
-    esac
+    if [ "$?" -eq 0 ]; then
+        do_start
+        case "$?" in
+            0) log_end_msg 0 ;;
+            1) log_end_msg 1 ;; # Old process is still running
+            *) log_end_msg 1 ;; # Failed to start
+        esac
+    else
+        # Failed to stop
+        log_end_msg 1
+    fi
 }
 
 #
 # Function that sends a SIGHUP to the daemon/service
 #
 do_reload() {
-    /opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME} reload
+    "${INSTALL_DIR}/bin/${REALNAME}" reload
     return $?
 }
 
@@ -157,10 +145,11 @@ case "$1" in
         [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
         do_stop
         RETVAL="$?"
-        case "$RETVAL" in
-            0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-            2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-        esac
+        if [ "$RETVAL" -eq 0 ]; then
+            [ "$VERBOSE" != no ] && log_end_msg 0
+        else
+            [ "$VERBOSE" != no ] && log_end_msg 1
+        fi
         exit "$RETVAL"
         ;;
     status)

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
@@ -26,6 +26,7 @@ ExecStartPre=<%= action %>
 
 ExecReload=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> reload
 ExecStart=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
+ExecStop=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> stop
 
 KillMode=process
 

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
@@ -26,6 +26,7 @@ ExecStartPre=<%= action %>
 
 ExecReload=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> reload
 ExecStart=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
+ExecStop=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> stop
 
 KillMode=process
 

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -104,6 +104,8 @@ Requires:         %{open_jdk}
 # net-tools is required for netstat usage in service unit file
 # See: https://tickets.puppetlabs.com/browse/SERVER-338
 Requires:         net-tools
+# procps is required for pgrep, used in several of the init scripts
+Requires:         procps
 <% EZBake::Config[:redhat][:additional_build_dependencies].each do |dep| %>
 BuildRequires:    <%= dep %>
 <% end %>

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -72,7 +72,7 @@ start() {
     <% end -%>
 
     pushd "${INSTALL_DIR}" &> /dev/null
-    daemon --user $USER --pidfile $PIDFILE "/opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1"
+    daemon --user $USER --pidfile $PIDFILE "${INSTALL_DIR}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1"
     retval=$?
     popd &> /dev/null
     [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"
@@ -92,13 +92,7 @@ start() {
 
 stop() {
     echo -n $"Stopping $prog: "
-    find_my_pid
-
-    if [ ! -s "$PIDFILE" ] ; then
-        echo $pid > $PIDFILE
-    fi
-
-    killproc -p $PIDFILE -d ${SERVICE_STOP_RETRIES}s $prog
+    "${INSTALL_DIR}/bin/${realname}" stop
     retval=$?
 
     [ $retval -eq 0 ] && success $"$base stopped" || failure $"$base stopped"
@@ -123,7 +117,7 @@ rh_status_q() {
 
 reload() {
     echo -n $"Reloading $prog: "
-    /opt/puppetlabs/server/apps/${realname}/bin/${realname} reload
+    "${INSTALL_DIR}/bin/${realname}" reload
     RETVAL=$?
 
     [ $RETVAL -eq 0 ] && success $"$base reloaded" || failure $"$base reloaded"

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
@@ -3,6 +3,8 @@ set +e
 
 restartfile=<%= EZBake::Config[:restart_file] %>
 timeout=<%= EZBake::Config[:start_timeout] %>
+realname="<%= EZBake::Config[:real_name] %>"
+PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 
 if [ -r "$restartfile" ];  then
     pid=$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)
@@ -17,6 +19,7 @@ if [ -r "$restartfile" ];  then
         kill -0 $pid >/dev/null 2>&1
         if [ $? -ne 0 ]; then
             echo "Process $pid exited before reload had completed" 1>&2
+            rm -f "$PIDFILE"
             exit 1
         fi
         sleep 0.1

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -9,7 +9,12 @@ dir=$(dirname "$restartfile")
 realname="<%= EZBake::Config[:real_name] %>"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 
-[ -e "${INSTALL_DIR}/ezbake-functions.sh" ] && . "${INSTALL_DIR}/ezbake-functions.sh"
+if [ ! -e "${INSTALL_DIR}/ezbake-functions.sh" ]; then
+    echo "Unable to find ${INSTALL_DIR}/ezbake-functions.sh script, failing start." 1>&2
+    exit 1
+fi
+
+. "${INSTALL_DIR}/ezbake-functions.sh"
 
 write_pid_file() {
     if [ ! -d "/var/run/puppetlabs/${realname}" ]; then

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -5,10 +5,11 @@ pid=$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)
 
 restartfile=<%= EZBake::Config[:restart_file] %>
 start_timeout=<%= EZBake::Config[:start_timeout] %>
-stop_timeout=60
 dir=$(dirname "$restartfile")
 realname="<%= EZBake::Config[:real_name] %>"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
+
+[ -e "${INSTALL_DIR}/ezbake-functions.sh" ] && . "${INSTALL_DIR}/ezbake-functions.sh"
 
 write_pid_file() {
     if [ ! -d "/var/run/puppetlabs/${realname}" ]; then
@@ -20,28 +21,7 @@ write_pid_file() {
 
 terminate_java_process() {
     echo "Startup script was terminated before completion" 1>&2
-    kill -TERM $pid >/dev/null 2>&1
-    sleep 0.1
-
-    timeout=$stop_timeout
-    kill -0 $pid >/dev/null 2>&1
-    while [ $? -eq 0 ] && [ $timeout -ne 0 ]; do
-        sleep 1
-        ((timeout--))
-        kill -0 $pid >/dev/null 2>&1
-    done
-
-    if [ $timeout -eq 0 ]; then
-        echo "Java process $pid not terminated gracefully after $stop_timeout seconds" 1>&2
-        kill -KILL $pid >/dev/null 2>&1
-        sleep 1
-        kill -0 $pid >/dev/null 2>&1
-        if [ $? -eq 0 ]; then
-            echo "Java process $pid not killed after SIGKILL" 1>&2
-        fi
-    fi
-
-    rm -f "$PIDFILE"
+    kill_pid $pid $PIDFILE $SERVICE_STOP_RETRIES
     exit 1
 }
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -30,7 +30,7 @@ terminate_java_process() {
     exit 1
 }
 
-if [ ! -z $pid ]; then
+if [ -n "$pid" ]; then
     write_pid_file $pid
     exit 0
 fi

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/stop.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/stop.erb
@@ -5,7 +5,12 @@ pid=$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)
 realname="<%= EZBake::Config[:real_name] %>"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 
-[ -e "${INSTALL_DIR}/ezbake-functions.sh" ] && . "${INSTALL_DIR}/ezbake-functions.sh"
+if [ ! -e "${INSTALL_DIR}/ezbake-functions.sh" ]; then
+    echo "Unable to find ${INSTALL_DIR}/ezbake-functions.sh script, failing stop." 1>&2
+    exit 1
+fi
+
+. "${INSTALL_DIR}/ezbake-functions.sh"
 
 if [ -z $pid ]; then
     rm -f "$PIDFILE"

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/stop.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/stop.erb
@@ -12,7 +12,7 @@ fi
 
 . "${INSTALL_DIR}/ezbake-functions.sh"
 
-if [ -z $pid ]; then
+if [ -z "$pid" ]; then
     rm -f "$PIDFILE"
     exit 0
 else

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/stop.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/stop.erb
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set +e
+
+pid=$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)
+realname="<%= EZBake::Config[:real_name] %>"
+PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
+
+[ -e "${INSTALL_DIR}/ezbake-functions.sh" ] && . "${INSTALL_DIR}/ezbake-functions.sh"
+
+if [ -z $pid ]; then
+    rm -f "$PIDFILE"
+    exit 0
+else
+    kill_pid $pid $PIDFILE $SERVICE_STOP_RETRIES
+fi

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake-functions.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake-functions.sh.erb
@@ -105,7 +105,7 @@ kill_pid()
         fi
     fi
 
-    if [ ! -z $pidfile ]; then
+    if [ -n "$pidfile" ]; then
         rm -f "$pidfile"
     fi
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake-functions.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake-functions.sh.erb
@@ -61,6 +61,57 @@ wait_for_pidfile()
     return 0
 }
 
+#
+# Kill a process.
+#
+# First argument (required) is the pid to kill.
+#
+# Second argument (optional) is a pidfile that should be removed after the
+# process is killed.
+#
+# Third argument (optional) is a timeout (in seconds) to wait for the process
+# to die.  Default timeout is 60 seconds.
+#
+# Returns 0 (success) if the process is dead or 1 (failure) if the process is
+# still running after attempts to kill have completed.
+#
+kill_pid()
+{
+    local pid=${1:?}
+    local pidfile=$2
+    local stop_timeout=${3:-60}
+
+    kill -TERM $pid >/dev/null 2>&1
+    sleep 0.1
+
+    timeout=$stop_timeout
+    kill -0 $pid >/dev/null 2>&1
+    while [ $? -eq 0 ] && [ $timeout -ne 0 ]; do
+        sleep 1
+        ((timeout--))
+        kill -0 $pid >/dev/null 2>&1
+    done
+
+    if [ $timeout -eq 0 ]; then
+        echo "Process $pid not terminated gracefully after $stop_timeout seconds" 1>&2
+        kill -KILL $pid >/dev/null 2>&1
+        sleep 1
+        kill -0 $pid >/dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            echo "Process $pid not killed after SIGKILL" 1>&2
+            return 1
+        else
+            echo "Process $pid killed after SIGKILL" 1>&2
+        fi
+    fi
+
+    if [ ! -z $pidfile ]; then
+        rm -f "$pidfile"
+    fi
+
+    return 0
+}
+
 if [ "$0" = "$BASH_SOURCE" ] ;then
     COMMAND=${1:?}
     export $(systemctl show -p MainPID <%= EZBake::Config[:project] %>.service)

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/control.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/control.erb
@@ -13,7 +13,8 @@ Package: <%= EZBake::Config[:project] %>
 Architecture: all
 # net-tools is required for netstat usage in service unit file
 # See: https://tickets.puppetlabs.com/browse/SERVER-338
-Depends: ${misc:Depends}, pe-java, pe-puppet-enterprise-release, net-tools, adduser<%=
+# procps is required for pgrep, used in several of the init scripts
+Depends: ${misc:Depends}, pe-java, pe-puppet-enterprise-release, net-tools, adduser, procps<%=
     if !EZBake::Config[:debian][:additional_dependencies].empty?
       ", " + EZBake::Config[:debian][:additional_dependencies].join(", ")
     end %>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -63,7 +63,7 @@ do_start()
     <% end -%>
 
     start-stop-daemon --start --quiet --chuid $USER --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR \
-      --startas "/opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME}" -- start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1
+      --startas "${INSTALL_DIR}/bin/${REALNAME}" -- start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1
     retval=$?
 
     <% if not EZBake::Config[:debian][:post_start_action].empty? -%>
@@ -82,16 +82,7 @@ do_start()
 #
 do_stop()
 {
-    # Return
-    #   0 if daemon has been stopped or was already stopped
-    #   2 if daemon could not be stopped
-    #   other if a failure occurred
-    start-stop-daemon --stop --quiet --oknodo --retry=TERM/${SERVICE_STOP_RETRIES}/KILL/5 --pidfile $PIDFILE --exec $JAVA_BIN
-    RETVAL="$?"
-    [ "$RETVAL" = 2 ] && return 2
-    # Many daemons don't delete their pidfiles when they exit.
-    rm -f $PIDFILE
-    return "$RETVAL"
+    "${INSTALL_DIR}/bin/${REALNAME}" stop
 }
 
 #
@@ -119,27 +110,24 @@ get_status_q()
 do_restart()
 {
     do_stop
-    case "$?" in
-        0|1)
-            do_start
-            case "$?" in
-                0) log_end_msg 0 ;;
-                1) log_end_msg 1 ;; # Old process is still running
-                *) log_end_msg 1 ;; # Failed to start
-            esac
-            ;;
-        *)
-            # Failed to stop
-            log_end_msg 1
-            ;;
-    esac
+    if [ "$?" -eq 0 ]; then
+      do_start
+      case "$?" in
+          0) log_end_msg 0 ;;
+          1) log_end_msg 1 ;; # Old process is still running
+          *) log_end_msg 1 ;; # Failed to start
+      esac
+    else
+      # Failed to stop
+      log_end_msg 1
+    fi
 }
 
 #
 # Function that sends a SIGHUP to the daemon/service
 #
 do_reload() {
-    /opt/puppetlabs/server/apps/${REALNAME}/bin/${REALNAME} reload
+    "${INSTALL_DIR}/bin/${REALNAME}" reload
     return $?
 }
 
@@ -158,10 +146,11 @@ case "$1" in
         [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
         do_stop
         RETVAL="$?"
-        case "$RETVAL" in
-            0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-            2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-        esac
+        if [ "$RETVAL" -eq 0 ]; then
+            [ "$VERBOSE" != no ] && log_end_msg 0
+        else
+            [ "$VERBOSE" != no ] && log_end_msg 1
+        fi
         exit "$RETVAL"
         ;;
     status)

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
@@ -26,6 +26,7 @@ ExecStartPre=<%= action %>
 
 ExecReload=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> reload
 ExecStart=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
+ExecStop=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> stop
 
 KillMode=process
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
@@ -26,6 +26,7 @@ ExecStartPre=<%= action %>
 
 ExecReload=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> reload
 ExecStart=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start
+ExecStop=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> stop
 
 KillMode=process
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -103,6 +103,8 @@ Requires:         pe-puppet-enterprise-release
 # net-tools is required for netstat usage in service unit file
 # See: https://tickets.puppetlabs.com/browse/SERVER-338
 Requires:         net-tools
+# procps is required for pgrep, used in several of the init scripts
+Requires:         procps
 <% EZBake::Config[:redhat][:additional_build_dependencies].each do |dep| %>
 BuildRequires:    <%= dep %>
 <% end %>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -72,7 +72,7 @@ start() {
     <% end -%>
 
     pushd "${INSTALL_DIR}" &> /dev/null
-    daemon --user $USER --pidfile $PIDFILE "/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin/<%= EZBake::Config[:real_name] %> start"
+    daemon --user $USER --pidfile $PIDFILE "${INSTALL_DIR}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1"
     retval=$?
     popd &> /dev/null
     [ -s $PIDFILE ] && success $"$base startup" || failure $"$base startup"
@@ -92,13 +92,7 @@ start() {
 
 stop() {
     echo -n $"Stopping $prog: "
-    find_my_pid
-
-    if [ ! -s "$PIDFILE" ] ; then
-        echo $pid > $PIDFILE
-    fi
-
-    killproc -p $PIDFILE -d ${SERVICE_STOP_RETRIES}s $prog
+    "${INSTALL_DIR}/bin/${realname}" stop
     retval=$?
 
     [ $retval -eq 0 ] && success $"$base stopped" || failure $"$base stopped"
@@ -123,7 +117,7 @@ rh_status_q() {
 
 reload() {
     echo -n $"Reloading $prog: "
-    /opt/puppetlabs/server/apps/${realname}/bin/${realname} reload
+    "${INSTALL_DIR}/bin/${realname}" reload
     RETVAL=$?
 
     [ $RETVAL -eq 0 ] && success $"$base reloaded" || failure $"$base reloaded"

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -51,15 +51,6 @@ START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 # First reset status of this service
 rc_reset
 
-print_service_pid() {
-    local pid
-    if [ ! -d  "/var/run/puppetlabs/${realname}" ] ; then
-        install --owner "${USER}" --group "${USER}" --directory "/var/run/puppetlabs/${realname}"
-    fi
-    pid="$(pgrep -f "${JAVA_BIN}.*${JARFILE}")"
-    echo -n "${pid}"
-}
-
 start() {
     local service_pid
     [ -x "${JAVA_BIN}" ] || exit 5
@@ -84,16 +75,13 @@ start() {
     # startproc will change users, so make sure that user has permission
     # to access the present working directory.
     cd "${INSTALL_DIR}"
-    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" "/opt/puppetlabs/server/apps/${realname}/bin/${realname} start >> /var/log/puppetlabs/${realname}/${realname}-daemon.log 2>&1"
+    startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -w -- "${INSTALL_DIR}/bin/${realname}" start >/dev/null 2>&1
+    [ ! -z $(pgrep -f <%= EZBake::Config[:uberjar_name] %>) ]
     rc_status -v
-    retval=$?
 
-    # If rc_status didn't succeed, bail out early without bothering to poll
-    # waiting for the application or doing work that assumes a launching state
-    if [ "$retval" != 0 ]; then
-        log_failure_msg $"${prog} startup"
-        echo
-        return $retval
+    retval=$?
+    if [ "$retval" -eq 0 ]; then
+        touch "${lockfile}"
     fi
 
     <% if not EZBake::Config[:redhat][:post_start_action].empty? -%>
@@ -104,39 +92,20 @@ start() {
     fi
     <% end -%>
 
-    # if the pid file exists, with the PID in it (non-zero size)
-    if [ -s "${PIDFILE}" ]; then
-        log_success_msg $"${prog} startup"
-        echo
-        touch "${lockfile}"
-        return 0
-    else
-        log_failure_msg $"${prog} startup"
-        echo
-        return 1
-    fi
+    return $retval
 }
 
 stop() {
     echo -n $"Stopping ${prog}: "
-    if [ ! -s "${PIDFILE}" ] ; then
-        print_service_pid > "${PIDFILE}"
-    fi
-
-    killproc -p "${PIDFILE}" -t"${SERVICE_STOP_RETRIES}"s -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\"" "${JAVA_ARGS}"
+    "${INSTALL_DIR}/bin/${realname}" stop
     rc_status -v
     retval=$?
 
-    if [ "$retval" = 0 ]; then
-        rm -f "${lockfile}" "${PIDFILE}"
-        log_success_msg $"${prog} stopped"
-        echo
-        return 0
-    else
-        log_failure_msg $"${prog} could not be stopped, check ${LOGFILE}"
-        echo
-        return 1
+    if [ "$retval" -eq 0 ]; then
+        rm -f "${lockfile}"
     fi
+
+    return $retval
 }
 
 restart() {
@@ -149,27 +118,23 @@ sl_status_q() {
 }
 
 sl_status() {
+    echo -n $"Checking for service ${prog}: "
     checkproc -p "${PIDFILE}" -- "${JAVA_BIN}" "-XX:OnOutOfMemoryError=\"kill -9 %p\"" "${JAVA_ARGS}"
     rc_status -v
 }
 
 reload() {
-    echo -n $"Reloading ${prog}:"
-    /opt/puppetlabs/server/apps/${realname}/bin/${realname} reload
+    echo -n $"Reloading ${prog}: "
+    "${INSTALL_DIR}/bin/${realname}" reload
     rc_status -v
     retval=$?
 
-    if [ "$retval" = 0 ]; then
-        log_success_msg $"${prog} reloaded"
-        echo
-        return 0
-    else
-        log_failure_msg $"${prog} could not be reloaded, check ${LOGFILE}"
-        echo
-        return 1
+    if [ "$retval" -ne 0 ] && [ -z $(pgrep -f <%= EZBake::Config[:uberjar_name] %>) ]; then
+        rm -f "${lockfile}"
     fi
-}
 
+    return $retval
+}
 
 case "$1" in
     start)

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -76,7 +76,7 @@ start() {
     # to access the present working directory.
     cd "${INSTALL_DIR}"
     startproc -u "${USER}" -l "${LOGFILE}" -p "${PIDFILE}" -w -- "${INSTALL_DIR}/bin/${realname}" start >/dev/null 2>&1
-    [ ! -z $(pgrep -f <%= EZBake::Config[:uberjar_name] %>) ]
+    [ -n "$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)" ]
     rc_status -v
 
     retval=$?

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -45,7 +45,7 @@ JARFILE="<%= EZBake::Config[:uberjar_name] %>"
 JAVA_ARGS="${JAVA_ARGS} -cp ${INSTALL_DIR}/${JARFILE} clojure.main -m <%= EZBake::Config[:main_namespace] %> --config ${CONFIG} -b ${BOOTSTRAP_CONFIG}"
 lockfile="/var/lock/subsys/${prog}"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
-LOGFILE="/var/log/puppetlabs/${realname}/${realname}.log"
+LOGFILE="/var/log/puppetlabs/${realname}/${realname}-daemon.log"
 START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 
 # First reset status of this service


### PR DESCRIPTION
This PR adds a TK stop subcommand script, which just gets the pid of
the service process, calls the kill_pid function to kill it, and nukes
the associated service pidfile.  This PR also modifies all of the OS init
scripts / systemd service definitions to invoke the new TK stop
subcommand to stop a service.

The commit also inlines some fully-qualified uses of
/opt/puppetlabs/server/apps/<app_name> with references to
$INSTALL_DIR, where possible.

For the SLES 11 init script, the startproc command line was also fixed
up such that the process will actually be started correctly and some
excess log message logic was removed.