### PR TITLE
(EZ-100) Add timeout settings for reload and stop

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -5,6 +5,7 @@ module EZBake
       :user           => '{{{user}}}',
       :restart_file   => '{{restart-file}}',
       :group          => '{{{group}}}',
+      :reload_timeout => '{{{reload-timeout}}}',
       :start_timeout  => '{{{start-timeout}}}',
       :open_file_limit => {{{open-file-limit}}},
       :uberjar_name   => '{{{uberjar-name}}}',

--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -7,6 +7,7 @@ module EZBake
       :group          => '{{{group}}}',
       :reload_timeout => '{{{reload-timeout}}}',
       :start_timeout  => '{{{start-timeout}}}',
+      :stop_timeout   => '{{{stop-timeout}}}',
       :open_file_limit => {{{open-file-limit}}},
       :uberjar_name   => '{{{uberjar-name}}}',
       :config_files   => [{{{config-files}}}],

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
@@ -7,7 +7,7 @@ Type=forking
 EnvironmentFile=/etc/default/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
-TimeoutStopSec=60
+TimeoutStopSec=<%= EZBake::Config[:stop_timeout] %>
 Restart=on-failure
 StartLimitBurst=5
 PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>.pid

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
@@ -35,3 +35,7 @@ SERVICE_STOP_RETRIES=60
 # will have no effect in systemd.
 OPEN_FILE_LIMIT=<%= EZBake::Config[:open_file_limit] %>
 <% end -%>
+
+# Maximum number of seconds that can expire for a service reload attempt before
+# the result of the attempt is interpreted as a failure.
+RELOAD_TIMEOUT=<%= EZBake::Config[:reload_timeout] %>

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
@@ -24,10 +24,10 @@ BOOTSTRAP_CONFIG="/etc/puppetlabs/<%= EZBake::Config[:real_name] %>/bootstrap.cf
 SERVICE_STOP_RETRIES=60
 
 # START_TIMEOUT can be set here to alter the default startup timeout in
-# seconds.  This is used in System-V style init scripts only, and will have no
-# effect in systemd.
-# START_TIMEOUT=<%= EZBake::Config[:start_timeout] %>
-
+# seconds.  For systemd, the shorter of this setting or 'TimeoutStartSec'
+# in the service's systemd.service configuration file will effectively be the
+# timeout which is used.
+START_TIMEOUT=<%= EZBake::Config[:start_timeout] %>
 
 <% if EZBake::Config[:open_file_limit] -%>
 # OPEN_FILE_LIMIT can be set here to alter the number of open file descriptors

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
@@ -21,7 +21,10 @@ BOOTSTRAP_CONFIG="/etc/puppetlabs/<%= EZBake::Config[:real_name] %>/services.d/,
 BOOTSTRAP_CONFIG="/etc/puppetlabs/<%= EZBake::Config[:real_name] %>/bootstrap.cfg"
 <% end -%>
 
-SERVICE_STOP_RETRIES=60
+# SERVICE_STOP_RETRIES can be set here to alter the default stop timeout in
+# seconds.  For systemd, the shorter of this setting or 'TimeoutStopSec' in
+# the systemd.service definition will effectively be the timeout which is used.
+SERVICE_STOP_RETRIES=<%= EZBake::Config[:stop_timeout] %>
 
 # START_TIMEOUT can be set here to alter the default startup timeout in
 # seconds.  For systemd, the shorter of this setting or 'TimeoutStartSec'

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
@@ -7,7 +7,7 @@ Type=forking
 EnvironmentFile=/etc/sysconfig/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
-TimeoutStopSec=60
+TimeoutStopSec=<%= EZBake::Config[:stop_timeout] %>
 Restart=on-failure
 StartLimitBurst=5
 PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>.pid

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
@@ -2,7 +2,8 @@
 set +e
 
 restartfile=<%= EZBake::Config[:restart_file] %>
-timeout=<%= EZBake::Config[:start_timeout] %>
+reload_timeout=${RELOAD_TIMEOUT:-<%= EZBake::Config[:reload_timeout] %>}
+timeout=$reload_timeout
 realname="<%= EZBake::Config[:real_name] %>"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 
@@ -13,6 +14,7 @@ if [ -r "$restartfile" ];  then
         echo "Service not running so cannot be reloaded" 1>&2
         exit 1
     fi
+    sleep 0.1
     cur=$(head -n 1 "$restartfile")
     initial=$cur
     while [ "$cur" == "$initial" ] ;do
@@ -22,12 +24,12 @@ if [ -r "$restartfile" ];  then
             rm -f "$PIDFILE"
             exit 1
         fi
-        sleep 0.1
+        sleep 1
         cur=$(head -n 1 "$restartfile")
 
         ((timeout--))
         if [ $timeout -eq 0 ]; then
-            echo "Reload timed out after <%= EZBake::Config[:start_timeout].to_i / 10 %> seconds"
+            echo "Reload timed out after $reload_timeout seconds"
             exit 1
         fi
     done

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 set +e
 
-restartfile=<%= EZBake::Config[:restart_file] %>
-reload_timeout=${RELOAD_TIMEOUT:-<%= EZBake::Config[:reload_timeout] %>}
-timeout=$reload_timeout
+restartfile="<%= EZBake::Config[:restart_file] %>"
+reload_timeout="${RELOAD_TIMEOUT:-<%= EZBake::Config[:reload_timeout] %>}"
+timeout="$reload_timeout"
 realname="<%= EZBake::Config[:real_name] %>"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 
 if [ -r "$restartfile" ];  then
-    cur=$(head -n 1 "$restartfile")
-    initial=$cur
-    pid=$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)
+    cur="$(head -n 1 "$restartfile")"
+    initial="$cur"
+    pid="$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)"
     kill -HUP $pid >/dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo "Service not running so cannot be reloaded" 1>&2
@@ -25,7 +25,7 @@ if [ -r "$restartfile" ];  then
             exit 1
         fi
         sleep 1
-        cur=$(head -n 1 "$restartfile")
+        cur="$(head -n 1 "$restartfile")"
 
         ((timeout--))
         if [ $timeout -eq 0 ]; then

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
@@ -8,6 +8,8 @@ realname="<%= EZBake::Config[:real_name] %>"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 
 if [ -r "$restartfile" ];  then
+    cur=$(head -n 1 "$restartfile")
+    initial=$cur
     pid=$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)
     kill -HUP $pid >/dev/null 2>&1
     if [ $? -ne 0 ]; then
@@ -15,8 +17,6 @@ if [ -r "$restartfile" ];  then
         exit 1
     fi
     sleep 0.1
-    cur=$(head -n 1 "$restartfile")
-    initial=$cur
     while [ "$cur" == "$initial" ] ;do
         kill -0 $pid >/dev/null 2>&1
         if [ $? -ne 0 ]; then

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -4,7 +4,7 @@ set +e
 pid=$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)
 
 restartfile=<%= EZBake::Config[:restart_file] %>
-start_timeout=<%= EZBake::Config[:start_timeout] %>
+start_timeout=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 dir=$(dirname "$restartfile")
 realname="<%= EZBake::Config[:real_name] %>"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set +e
 
-pid=$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)
+pid="$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)"
 
-restartfile=<%= EZBake::Config[:restart_file] %>
-start_timeout=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
-dir=$(dirname "$restartfile")
+restartfile="<%= EZBake::Config[:restart_file] %>"
+start_timeout="${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}"
+dir="$(dirname "$restartfile")"
 realname="<%= EZBake::Config[:real_name] %>"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 
@@ -26,7 +26,7 @@ write_pid_file() {
 
 terminate_java_process() {
     echo "Startup script was terminated before completion" 1>&2
-    kill_pid $pid $PIDFILE $SERVICE_STOP_RETRIES
+    kill_pid "$pid" "$PIDFILE" "$SERVICE_STOP_RETRIES"
     exit 1
 }
 
@@ -52,10 +52,10 @@ pid=$!
 trap terminate_java_process SIGHUP SIGINT SIGTERM
 write_pid_file $pid
 
-cur=$(head -n 1 "$restartfile")
-initial=$cur
+cur="$(head -n 1 "$restartfile")"
+initial="$cur"
 
-timeout=$start_timeout
+timeout="$start_timeout"
 while [ "$cur" == "$initial" ] ;do
     kill -0 $pid >/dev/null 2>&1
     if [ $? -ne 0 ]; then
@@ -65,7 +65,7 @@ while [ "$cur" == "$initial" ] ;do
     fi
 
     sleep 1
-    cur=$(head -n 1 "$restartfile")
+    cur="$(head -n 1 "$restartfile")"
 
     ((timeout--))
     if [ $timeout -eq 0 ]; then

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -70,6 +70,8 @@ while [ "$cur" == "$initial" ] ;do
     ((timeout--))
     if [ $timeout -eq 0 ]; then
         echo "Startup timed out after $start_timeout seconds" 1>&2
+        terminate_java_process
+        rm -f "$PIDFILE"
         exit 1
     fi
 done

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/stop.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/stop.erb
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set +e
 
-pid=$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)
+pid="$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)"
 realname="<%= EZBake::Config[:real_name] %>"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 
@@ -16,5 +16,5 @@ if [ -z "$pid" ]; then
     rm -f "$PIDFILE"
     exit 0
 else
-    kill_pid $pid $PIDFILE $SERVICE_STOP_RETRIES
+    kill_pid "$pid" "$PIDFILE" "$SERVICE_STOP_RETRIES"
 fi

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake-functions.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake-functions.sh.erb
@@ -79,7 +79,7 @@ kill_pid()
 {
     local pid=${1:?}
     local pidfile=$2
-    local stop_timeout=${3:-60}
+    local stop_timeout=${3:-<%= EZBake::Config[:stop_timeout] %>}
 
     kill -TERM $pid >/dev/null 2>&1
     sleep 0.1

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
@@ -7,7 +7,7 @@ Type=forking
 EnvironmentFile=/etc/default/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
-TimeoutStopSec=60
+TimeoutStopSec=<%= EZBake::Config[:stop_timeout] %>
 Restart=on-failure
 StartLimitBurst=5
 PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>.pid

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/default.erb
@@ -34,3 +34,7 @@ SERVICE_STOP_RETRIES=60
 # will have no effect in systemd.
 OPEN_FILE_LIMIT=<%= EZBake::Config[:open_file_limit] %>
 <% end -%>
+
+# Maximum number of seconds that can expire for a service reload attempt before
+# the result of the attempt is interpreted as a failure.
+RELOAD_TIMEOUT=<%= EZBake::Config[:reload_timeout] %>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/default.erb
@@ -24,9 +24,10 @@ BOOTSTRAP_CONFIG="/etc/puppetlabs/<%= EZBake::Config[:real_name] %>/bootstrap.cf
 SERVICE_STOP_RETRIES=60
 
 # START_TIMEOUT can be set here to alter the default startup timeout in
-# seconds.  This is used in System-V style init scripts only, and will have no
-# effect in systemd.
-# START_TIMEOUT=<%= EZBake::Config[:start_timeout] %>
+# seconds.  For systemd, the shorter of this setting or 'TimeoutStartSec'
+# in the service's systemd.service configuration file will effectively be the
+# timeout which is used.
+START_TIMEOUT=<%= EZBake::Config[:start_timeout] %>
 
 <% if EZBake::Config[:open_file_limit] -%>
 # OPEN_FILE_LIMIT can be set here to alter the number of open file descriptors

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/default.erb
@@ -21,7 +21,10 @@ BOOTSTRAP_CONFIG="/etc/puppetlabs/<%= EZBake::Config[:real_name] %>/services.d/,
 BOOTSTRAP_CONFIG="/etc/puppetlabs/<%= EZBake::Config[:real_name] %>/bootstrap.cfg"
 <% end -%>
 
-SERVICE_STOP_RETRIES=60
+# SERVICE_STOP_RETRIES can be set here to alter the default stop timeout in
+# seconds.  For systemd, the shorter of this setting or 'TimeoutStopSec' in
+# the systemd.service definition will effectively be the timeout which is used.
+SERVICE_STOP_RETRIES=<%= EZBake::Config[:stop_timeout] %>
 
 # START_TIMEOUT can be set here to alter the default startup timeout in
 # seconds.  For systemd, the shorter of this setting or 'TimeoutStartSec'

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
@@ -7,7 +7,7 @@ Type=forking
 EnvironmentFile=/etc/sysconfig/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>
-TimeoutStopSec=60
+TimeoutStopSec=<%= EZBake::Config[:stop_timeout] %>
 Restart=on-failure
 StartLimitBurst=5
 PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>.pid

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -426,6 +426,7 @@ Dependency tree:
      :terminus-map              termini
      :replaces-pkgs             (get-local-ezbake-var lein-project :replaces-pkgs [])
      :start-after               (quoted-list (get-local-ezbake-var lein-project :start-after []))
+     :reload-timeout            (get-local-ezbake-var lein-project :reload-timeout "120")
      :start-timeout             (get-local-ezbake-var lein-project :start-timeout "300")
      :open-file-limit           (get-local-ezbake-var lein-project :open-file-limit "nil")
      :main-namespace            (get-local-ezbake-var lein-project

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -428,6 +428,7 @@ Dependency tree:
      :start-after               (quoted-list (get-local-ezbake-var lein-project :start-after []))
      :reload-timeout            (get-local-ezbake-var lein-project :reload-timeout "120")
      :start-timeout             (get-local-ezbake-var lein-project :start-timeout "300")
+     :stop-timeout              (get-local-ezbake-var lein-project :stop-timeout "60")
      :open-file-limit           (get-local-ezbake-var lein-project :open-file-limit "nil")
      :main-namespace            (get-local-ezbake-var lein-project
                                                       :main-namespace


### PR DESCRIPTION
This PR adds optional Ezbake config timeout settings for reload and stop, defaulting to 2 minutes and 60 seconds, respectively.  The settings are attached to the new `RELOAD_TIMEOUT` and pre-existing `SERVICE_STOP_TIMEOUT` default/sysconfig settings.

The PR also includes some code to terminate the Java process if the start timeout is reached during a startup attempt.