### PR TITLE
(EZ-98) Fail an ezbake package build attempt if restart-file not set

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,11 +4,26 @@
   :license {:name "Apache License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
-  :dependencies [[me.raynes/fs "1.4.6" :exclusions [org.clojure/clojure]]
+  :dependencies [;; begin version conflict resolution dependencies
+                 [org.clojure/tools.reader "1.0.0-beta1"]
+                 ;; end version conflict resolution dependencies
+
+                 [me.raynes/fs "1.4.6" :exclusions [org.clojure/clojure]]
                  [me.raynes/conch "0.8.0"]
                  [clj-time "0.6.0"]
                  [prismatic/schema "1.0.4"]
-                 [puppetlabs/typesafe-config "0.1.3" :exclusions [org.clojure/clojure]]]
+
+                 [puppetlabs/typesafe-config "0.1.5" :exclusions [org.clojure/clojure]]
+
+                 ;; trapperkeeper pulls in core.cache via core.async.  Since
+                 ;; lein pulls in its own (older) version of core.cache,
+                 ;; running ezbake as a plugin to another project via lein
+                 ;; produces a "Could not locate clojure/data/priority_map__init.class"
+                 ;; error.  Seems related to
+                 ;; https://github.com/technomancy/leiningen/issues/1563.  Excluding
+                 ;; core.cache here appears to avoid the conflict without requiring
+                 ;; consuming projects to do the same.
+                 [puppetlabs/trapperkeeper "1.5.0" :exclusions [org.clojure/core.cache]]]
 
   :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]
                  ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]

--- a/src/leiningen/ezbake.clj
+++ b/src/leiningen/ezbake.clj
@@ -26,6 +26,7 @@ Actions:
                   ezbake-core/resource-path)]
         (lein-ezbake-core/prepare-resource-dir project)
         (try
+          (ezbake-core/validate! project)
           (ezbake-core/init!)
           (ezbake-core/action action project build-target)
           (finally


### PR DESCRIPTION
This commit causes an ezbake package build attempt to fail if the
`restart-file` setting is not specified in the ezbake config.  This
check is being added because `restart-file` is essentially a required
setting for Ezbake 1.0+ in that it would be impossible to determine when
a service has been completely started without the use of the setting.