### PR TITLE
(EZ-101) Specify restart file option via TK command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ packaging.
 The branching strategy is now covered in the
 [Branching Strategy page on the EZBake wiki](https://github.com/puppetlabs/ezbake/wiki/Branching-Strategy).
 
+## Minimum Trapperkeeper version dependencies
+
+EZBake 1.0 and later utilize the `restart-file` feature in Trapperkeeper to
+monitor service start and reload status.  For this reason, the application
+being packaged must include Trapperkeeper 1.5.1 or later.  If an earlier
+version is used instead, the service will fail to be started properly due to
+the lack of support for the `-r | --restart-file` command line option in the
+earlier Trapperkeeper versions.
+
 ## Using
 
 To get started using EZBake, please add it to the `:plugins` key in your

--- a/README.md
+++ b/README.md
@@ -12,12 +12,21 @@ The branching strategy is now covered in the
 
 ## Minimum Trapperkeeper version dependencies
 
-EZBake 1.0 and later utilize the `restart-file` feature in Trapperkeeper to
-monitor service start and reload status.  For this reason, the application
-being packaged must include Trapperkeeper 1.5.1 or later.  If an earlier
-version is used instead, the service will fail to be started properly due to
-the lack of support for the `-r | --restart-file` command line option in the
-earlier Trapperkeeper versions.
+EZBake 1.0 and later utilize the
+![restart-file](https://github.com/puppetlabs/trapperkeeper/blob/1.5.1/documentation/Restart-File.md)
+feature in Trapperkeeper to monitor service start and reload status.  For this
+reason, the application being packaged must include Trapperkeeper 1.5.1 or
+later.  If an earlier version is used instead, the service will fail to be
+started properly due to the lack of support for the `-r | --restart-file`
+command line option in the earlier Trapperkeeper versions.
+
+The failure message would be written to the
+`/var/log/puppetlabs/<app>/<app>-daemon.log` file -- for sysvinit / upstart --
+or journal -- for systemd -- with text which looks like this:
+
+```
+Error(s) occurred while parsing command-line arguments: Unknown option: "--restart-file"
+```
 
 ## Using
 

--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -3,7 +3,6 @@ module EZBake
       :project        => '{{{project}}}',
       :real_name      => '{{{real-name}}}',
       :user           => '{{{user}}}',
-      :restart_file   => '{{restart-file}}',
       :group          => '{{{group}}}',
       :reload_timeout => '{{{reload-timeout}}}',
       :start_timeout  => '{{{start-timeout}}}',

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 
+restartfile="/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/restartcounter"
+
+if [ ! -e "${INSTALL_DIR}/ezbake-functions.sh" ]; then
+    echo "Unable to find ${INSTALL_DIR}/ezbake-functions.sh script, failing start." 1>&2
+    exit 1
+fi
+
+. "${INSTALL_DIR}/ezbake-functions.sh"
+
+init_restart_file "$restartfile" || exit $?
+
 if !(echo "${@}" | grep -e "--debug" -q)
 then
     LOG_APPENDER="-Dlogappender=STDOUT"
@@ -9,6 +20,7 @@ COMMAND="${JAVA_BIN} ${JAVA_ARGS} ${LOG_APPENDER} \
          -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> \
          clojure.main -m <%= EZBake::Config[:main_namespace] %> \
          --config ${CONFIG} --bootstrap-config ${BOOTSTRAP_CONFIG} \
+         --restart-file "${restartfile}" \
          ${@}"
 
 pushd "${INSTALL_DIR}" &> /dev/null

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set +e
 
-restartfile="<%= EZBake::Config[:restart_file] %>"
+restartfile="/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/restartcounter"
 reload_timeout="${RELOAD_TIMEOUT:-<%= EZBake::Config[:reload_timeout] %>}"
 timeout="$reload_timeout"
 realname="<%= EZBake::Config[:real_name] %>"
@@ -16,8 +16,7 @@ fi
 
 init_restart_file "$restartfile" || exit $?
 
-cur="$(head -n 1 "$restartfile")"
-initial="$cur"
+initial="$(head -n 1 "$restartfile")"
 pid="$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)"
 kill -HUP $pid >/dev/null 2>&1
 if [ $? -ne 0 ]; then
@@ -25,6 +24,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 sleep 0.1
+cur="$(head -n 1 "$restartfile")"
 while [ "$cur" == "$initial" ] ;do
     kill -0 $pid >/dev/null 2>&1
     if [ $? -ne 0 ]; then

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
@@ -7,35 +7,39 @@ timeout="$reload_timeout"
 realname="<%= EZBake::Config[:real_name] %>"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 
-if [ -r "$restartfile" ];  then
-    cur="$(head -n 1 "$restartfile")"
-    initial="$cur"
-    pid="$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)"
-    kill -HUP $pid >/dev/null 2>&1
-    if [ $? -ne 0 ]; then
-        echo "Service not running so cannot be reloaded" 1>&2
-        exit 1
-    fi
-    sleep 0.1
-    while [ "$cur" == "$initial" ] ;do
-        kill -0 $pid >/dev/null 2>&1
-        if [ $? -ne 0 ]; then
-            echo "Process $pid exited before reload had completed" 1>&2
-            rm -f "$PIDFILE"
-            exit 1
-        fi
-        sleep 1
-        cur="$(head -n 1 "$restartfile")"
-
-        ((timeout--))
-        if [ $timeout -eq 0 ]; then
-            echo "Reload timed out after $reload_timeout seconds"
-            exit 1
-        fi
-    done
-else
-    echo "Application '<%= EZBake::Config[:real_name] %>' does not support 'reload'"
+if [ ! -e "${INSTALL_DIR}/ezbake-functions.sh" ]; then
+    echo "Unable to find ${INSTALL_DIR}/ezbake-functions.sh script, failing start." 1>&2
     exit 1
 fi
+
+. "${INSTALL_DIR}/ezbake-functions.sh"
+
+init_restart_file "$restartfile" || exit $?
+
+cur="$(head -n 1 "$restartfile")"
+initial="$cur"
+pid="$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)"
+kill -HUP $pid >/dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Service not running so cannot be reloaded" 1>&2
+    exit 1
+fi
+sleep 0.1
+while [ "$cur" == "$initial" ] ;do
+    kill -0 $pid >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Process $pid exited before reload had completed" 1>&2
+        rm -f "$PIDFILE"
+        exit 1
+    fi
+    sleep 1
+    cur="$(head -n 1 "$restartfile")"
+
+    ((timeout--))
+    if [ $timeout -eq 0 ]; then
+        echo "Reload timed out after $reload_timeout seconds"
+        exit 1
+    fi
+done
 
 exit 0

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -5,7 +5,7 @@ pid="$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)"
 
 restartfile="<%= EZBake::Config[:restart_file] %>"
 start_timeout="${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}"
-dir="$(dirname "$restartfile")"
+
 realname="<%= EZBake::Config[:real_name] %>"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 
@@ -37,13 +37,7 @@ fi
 
 rm -f "$PIDFILE"
 
-if [ ! -e "$restartfile" ]; then
-    mkdir -p "$dir"
-    echo -n "0" > "$restartfile"
-elif [ ! -r "$restartfile" ] || [ ! -w "$restartfile" ]; then
-    echo "The restart-file at <%= EZBake::Config[:restart_file] %> is not readable and/or writeable." 1>&2
-    exit 1
-fi
+init_restart_file "$restartfile" || exit $?
 
 ${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=/dev/urandom -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> clojure.main -m <%= EZBake::Config[:main_namespace] %> --config "${CONFIG}" -b "${BOOTSTRAP_CONFIG}" &
 
@@ -59,9 +53,9 @@ timeout="$start_timeout"
 while [ "$cur" == "$initial" ] ;do
     kill -0 $pid >/dev/null 2>&1
     if [ $? -ne 0 ]; then
-      rm -f "$PIDFILE"
-      echo "Background process $pid exited before start had completed" 1>&2
-      exit 1
+        rm -f "$PIDFILE"
+        echo "Background process $pid exited before start had completed" 1>&2
+        exit 1
     fi
 
     sleep 1

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -39,7 +39,13 @@ rm -f "$PIDFILE"
 
 init_restart_file "$restartfile" || exit $?
 
-${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=/dev/urandom -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> clojure.main -m <%= EZBake::Config[:main_namespace] %> --config "${CONFIG}" -b "${BOOTSTRAP_CONFIG}" -r "${restartfile}" &
+${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=/dev/urandom \
+  -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> \
+  clojure.main \
+  -m <%= EZBake::Config[:main_namespace] %> \
+  --config "${CONFIG}" \
+  --bootstrap-config "${BOOTSTRAP_CONFIG}" \
+  --restart-file "${restartfile}" &
 
 # $! is the process id of the last backgrounded process, the Java process above.
 pid=$!

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -3,7 +3,7 @@ set +e
 
 pid="$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)"
 
-restartfile="<%= EZBake::Config[:restart_file] %>"
+restartfile="/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/restartcounter"
 start_timeout="${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}"
 
 realname="<%= EZBake::Config[:real_name] %>"
@@ -39,7 +39,7 @@ rm -f "$PIDFILE"
 
 init_restart_file "$restartfile" || exit $?
 
-${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=/dev/urandom -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> clojure.main -m <%= EZBake::Config[:main_namespace] %> --config "${CONFIG}" -b "${BOOTSTRAP_CONFIG}" &
+${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=/dev/urandom -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> clojure.main -m <%= EZBake::Config[:main_namespace] %> --config "${CONFIG}" -b "${BOOTSTRAP_CONFIG}" -r "${restartfile}" &
 
 # $! is the process id of the last backgrounded process, the Java process above.
 pid=$!

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake-functions.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake-functions.sh.erb
@@ -112,6 +112,44 @@ kill_pid()
     return 0
 }
 
+init_restart_file()
+{
+    local restart_file="${1:?}"
+    local restart_file_base_dir="$(dirname "$restartfile")"
+    local user="${USER:-<%= EZBake::Config[:user] %>}"
+    local group="${GROUP:-<%= EZBake::Config[:group] %>}"
+
+    if [ ! -e "$restartfile" ]; then
+        if [ ! -d "$restart_file_base_dir" ]; then
+            mkdir -p "$restart_file_base_dir"
+            if [ $? -ne 0 ]; then
+                echo "Unable to create base directory for restart file at ${restart_file_base_dir}" 1>&2
+                return 1
+            fi
+            chown $user:$group "$restart_file_base_dir"
+            if [ $? -ne 0 ]; then
+                echo "Unable to create set permissions for restart file at ${restart_file_base_dir}" 1>&2
+                return 1
+            fi
+        fi
+        echo -n "0" > "$restart_file"
+        if [ $? -ne 0 ]; then
+            echo "Unable to create restart file at ${restart_file}" 1>&2
+            return 1
+        fi
+        chown $user:$group "$restart_file"
+        if [ $? -ne 0 ]; then
+            echo "Unable to set permissions for restart file at ${restart_file}" 1>&2
+            return 1
+        fi
+    elif [ ! -r "$restart_file" ] || [ ! -w "$restart_file" ]; then
+        echo "The restart-file at ${restart_file} is not readable and/or writeable." 1>&2
+        return 1
+    fi
+
+    return 0
+}
+
 if [ "$0" = "$BASH_SOURCE" ] ;then
     COMMAND=${1:?}
     export $(systemctl show -p MainPID <%= EZBake::Config[:project] %>.service)

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake-functions.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake-functions.sh.erb
@@ -128,7 +128,7 @@ init_restart_file()
             fi
             chown $user:$group "$restart_file_base_dir"
             if [ $? -ne 0 ]; then
-                echo "Unable to create set permissions for restart file at ${restart_file_base_dir}" 1>&2
+                echo "Unable to set permissions for base directory of restart file at ${restart_file_base_dir}" 1>&2
                 return 1
             fi
         fi

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -399,8 +399,6 @@ Dependency tree:
                                                       (:name lein-project))
      :group                     (get-local-ezbake-var lein-project :group
                                                       (:name lein-project))
-     :restart-file              (get-local-ezbake-var lein-project :restart-file
-                                                      (:restart-file lein-project))
      :uberjar-name              (:uberjar-name lein-project)
      :config-files              (quoted-list (map remove-erb-extension config-files))
      :system-config-files       (quoted-list (map remove-erb-extension system-config-files))


### PR DESCRIPTION
This PR adds "restart-file" to the Java command lines in the start
and foreground scripts and eliminates the use of a "restart-file"
EzBake config option for determining the location of the file.  EzBake
instead uses a default for the file which is based on the "realname"
of the package, `/opt/puppetlabs/server/data/[pkg-name]/restartcounter`,
and no longer has to depend upon corresponding TK global
configuration to be set to the same value in order for a service to be
started properly.