### PR TITLE
Debian systems can be runtime-switched between sysvinit and systemd

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/postinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/postinst.erb
@@ -4,12 +4,8 @@
 
 # On upgrade, we should restart the service if it's running
 if [ $1 = 'configure' -a -n $2 ] ; then
-  if [ -e "/lib/systemd/system/<%= EZBake::Config[:project] -%>.service" ] ; then
+  if [ -d /run/systemd/system ]; then
     # Using systemd
-    if [ -e '/etc/init.d/<%= EZBake::Config[:project] %>' ] ; then
-      # We need to clean up the old sysv files if they still exist
-      rm '/etc/init.d/<%= EZBake::Config[:project] %>'
-    fi
     systemctl daemon-reload >/dev/null 2>&1 || :
     systemctl try-restart <%= EZBake::Config[:project] %>.service ||:
   else

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/prerm.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/prerm.erb
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$1" = "failed-upgrade" ] || [ "$1" = "remove" ] ; then
-  if [ -e "/lib/systemd/system/<%= EZBake::Config[:project] -%>.service" ] ; then
+  if [ -d /run/systemd/system ]; then
     # Using systemd
     systemctl --no-reload disable <%= EZBake::Config[:project] -%>.service > /dev/null 2>&1 || :
     systemctl stop <%= EZBake::Config[:project] -%>.service > /dev/null 2>&1 || :

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -78,12 +78,7 @@ function task_service {
     elif [ "$OSFAMILY" = "Debian" ]; then
         unitdir=${unitdir_debian}
         defaultsdir=${defaultsdir_debian}
-        sysv_codenames=("squeeze" "wheezy" "lucid" "precise" "trusty" "jessie")
-        if $(echo ${sysv_codenames[@]} | grep -q $CODENAME) ; then
-            task install_source_deb_sysv
-        else
-            task install_source_deb_systemd
-        fi
+        task install_source_deb
     else
         echo "Unsupported platform, exiting ..."
         exit 1
@@ -111,18 +106,11 @@ function task_install_source_rpm_systemd {
 }
 
 # Source based install for Debian based setups
-function task_install_source_deb_sysv {
+function task_install_source_deb {
     task preinst_deb
     task install_deb
+    task defaults_deb
     task sysv_init_deb
-    task logrotate
-    task postinst_deb
-}
-
-# Source based install for Debian based + systemd setups
-function task_install_source_deb_systemd {
-    task preinst_deb
-    task install_deb
     task systemd_deb
     task logrotate
     task postinst_deb
@@ -244,17 +232,15 @@ function task_systemd_redhat {
     install -m 0644 ext/<%= EZBake::Config[:project] %>.tmpfiles.conf "${DESTDIR}${tmpfilesdir}/<%= EZBake::Config[:project] %>.conf"
 }
 
-# Install the sysv and defaults configuration for Debian.
+# Install the sysv init scripts for Debian.
 function task_sysv_init_deb {
-    task defaults_deb
     install -d -m 0755 "${DESTDIR}${initdir}"
     install -m 0755 ext/debian/<%= EZBake::Config[:project] %>.init_script "${DESTDIR}${initdir}/<%= EZBake::Config[:project] %>"
     install -d -m 0755 "${DESTDIR}${rundir}"
 }
 
-# Install the systemd and defaults configuration for Debian.
+# Install the systemd configuration for Debian.
 function task_systemd_deb {
-    task defaults_deb
     install -d -m 0755 "${DESTDIR}${unitdir_debian}"
     install -m 0644 ext/debian/<%= EZBake::Config[:project] %>.service_file "${DESTDIR}${unitdir_debian}/<%= EZBake::Config[:project] %>.service"
     install -d -m 0755 "${DESTDIR}${tmpfilesdir}"

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/postinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/postinst.erb
@@ -4,12 +4,7 @@
 
 # On upgrade, we should restart the service if it's running
 if [ $1 = 'configure' -a -n $2 ] ; then
-  if [ -e "/lib/systemd/system/<%= EZBake::Config[:project] -%>.service" ] ; then
-    # Using systemd
-    if [ -e '/etc/init.d/<%= EZBake::Config[:project] %>' ] ; then
-      # We need to clean up the old sysv files if they still exist
-      rm '/etc/init.d/<%= EZBake::Config[:project] %>'
-    fi
+  if [ -d /run/systemd/system ]; then
     systemctl daemon-reload >/dev/null 2>&1 || :
     systemctl try-restart <%= EZBake::Config[:project] %>.service ||:
   else

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/prerm.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/prerm.erb
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$1" = "failed-upgrade" ] || [ "$1" = "remove" ] ; then
-  if [ -e "/lib/systemd/system/<%= EZBake::Config[:project] -%>.service" ] ; then
+  if [ -d /run/systemd/system ]; then
     # Using systemd
     systemctl --no-reload disable <%= EZBake::Config[:project] -%>.service > /dev/null 2>&1 || :
     systemctl stop <%= EZBake::Config[:project] -%>.service > /dev/null 2>&1 || :


### PR DESCRIPTION
d2ad06508bed added systemd support for Ubuntu xenial, and as noted there did not enable it for jessie. Also, Debian-based systems can be runtime-switched between systemd and sysvinit, so packages should always install support for both init systems.

Actually doing this makes the code smaller, and now supports jessie, too.
