### PR TITLE
(MAINT) Set umask to 027 in cli app script

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/cli-app.erb
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/cli-app.erb
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#set default privileges to -rw-r-----
+umask 027
+
 set -a
 if [ -r "/etc/default/<%= EZBake::Config[:project] -%>" ] ; then
     . /etc/default/<%= EZBake::Config[:project] %>


### PR DESCRIPTION
In EZ-83, work was done across various init scripts / system service
definitions to set the default umask to 027.  Since some of the cli
subcommands - notably, foreground - are not typically initiated from an
init script / service context, they would still run with the default
system umask.  This commit adds the same explicit umask to the cli app
script for consistency - ensuring that when adhoc commands like
foreground are run that files like logs are not created with undesirable
world-accessible permissions.