### PR TITLE
(MAINT) Run `lein install` before stage

### DIFF
--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -495,6 +495,10 @@ Dependency tree:
 
 (defmethod action "stage"
   [_ lein-project build-target]
+  (lein-main/info "Running 'lein install' to pick up local changes.")
+  (let [result (exec/exec "lein" "install")]
+    (lein-main/info (:out result))
+    (lein-main/info (:err result)))
   (let [template-dir (get-template-file build-target)
         uberjar-name (:uberjar-name lein-project)]
     (uberjar/uberjar lein-project)


### PR DESCRIPTION
Prior to this commit, if you had made certain kinds of
changes to your local project and then run ezbake without
first running `lein install`, those changes would not get
included in the build, because ezbake pulls the jar from
the local m2 repo.

When this happened you'd usually lose at least 30 mins of
productivity in waiting for the builds and then debugging
them after they turned out not to match your local
environment.

This commit adds a call to `lein install` at the beginning
of `stage`, which will ensure that local changes are always
picked up when you run ezbake.