### PR TITLE
(maint) Add a comment about setting limits in the systemd service file

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.service.erb
@@ -1,3 +1,13 @@
+#
+# Local settings can be configured without being overwritten by package upgrades, for example
+# if you want to increase <%= EZBake::Config[:project] %> open-files-limit to 10000,
+# you need to increase systemd's LimitNOFILE setting, so create a file named
+# "/etc/systemd/system/<%= EZBake::Config[:project] %>.service.d/limits.conf" containing:
+#	[Service]
+#	LimitNOFILE=10000
+# You can confirm it worked by running systemctl daemon-reload
+# then running systemctl show <%= EZBake::Config[:project] %> | grep LimitNOFILE
+#
 [Unit]
 Description=<%= EZBake::Config[:project] %> Service
 After=syslog.target network.target

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.service.erb
@@ -1,3 +1,13 @@
+#
+# Local settings can be configured without being overwritten by package upgrades, for example
+# if you want to increase <%= EZBake::Config[:project] %> open-files-limit to 10000,
+# you need to increase systemd's LimitNOFILE setting, so create a file named
+# "/etc/systemd/system/<%= EZBake::Config[:project] %>.service.d/limits.conf" containing:
+#	[Service]
+#	LimitNOFILE=10000
+# You can confirm it worked by running systemctl daemon-reload
+# then running systemctl show <%= EZBake::Config[:project] %> | grep LimitNOFILE
+#
 [Unit]
 Description=<%= EZBake::Config[:project] %> Service
 After=syslog.target network.target

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.service.erb
@@ -1,3 +1,13 @@
+#
+# Local settings can be configured without being overwritten by package upgrades, for example
+# if you want to increase <%= EZBake::Config[:project] %> open-files-limit to 10000,
+# you need to increase systemd's LimitNOFILE setting, so create a file named
+# "/etc/systemd/system/<%= EZBake::Config[:project] %>.service.d/limits.conf" containing:
+#	[Service]
+#	LimitNOFILE=10000
+# You can confirm it worked by running systemctl daemon-reload
+# then running systemctl show <%= EZBake::Config[:project] %> | grep LimitNOFILE
+#
 [Unit]
 Description=<%= EZBake::Config[:project] %> Service
 After=syslog.target network.target

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.service.erb
@@ -1,3 +1,13 @@
+#
+# Local settings can be configured without being overwritten by package upgrades, for example
+# if you want to increase <%= EZBake::Config[:project] %> open-files-limit to 10000,
+# you need to increase systemd's LimitNOFILE setting, so create a file named
+# "/etc/systemd/system/<%= EZBake::Config[:project] %>.service.d/limits.conf" containing:
+#	[Service]
+#	LimitNOFILE=10000
+# You can confirm it worked by running systemctl daemon-reload
+# then running systemctl show <%= EZBake::Config[:project] %> | grep LimitNOFILE
+#
 [Unit]
 Description=<%= EZBake::Config[:project] %> Service
 After=syslog.target network.target <%= EZBake::Config[:start_after].map {|dep| "#{dep}.service" }.join(" ") %>


### PR DESCRIPTION
This is to document how to correctly set limits in an upgrade-safe way.