### PR TITLE
(EZ-103) Address incorrect rundir perms

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -32,6 +32,8 @@ fi
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 NAME=<%= EZBake::Config[:project] %>
 REALNAME=<%= EZBake::Config[:real_name] %>
+USER=<%= EZBake::Config[:user] %>
+GROUP=<%= EZBake::Config[:group] %>
 DESC="<%= EZBake::Config[:project] %> Puppet Labs version-checking backend"
 JARFILE="<%= EZBake::Config[:uberjar_name] %>"
 PIDFILE=/var/run/puppetlabs/${REALNAME}/${REALNAME}.pid
@@ -61,6 +63,8 @@ do_start()
     <% EZBake::Config[:debian][:pre_start_action].each do |action| -%>
     <%= action %>
     <% end -%>
+
+    /usr/bin/install --directory --owner=${USER} --group=${GROUP} --mode=775 /var/run/puppetlabs/${REALNAME}
 
     start-stop-daemon --start --quiet --chuid $USER --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR \
       --startas "${INSTALL_DIR}/bin/${REALNAME}" -- start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -48,10 +48,7 @@ START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 
 find_my_pid() {
     pid=`pgrep -f "${JARFILE}"`
-    if [ ! -d  "/var/run/puppetlabs/${realname}" ] ; then
-        mkdir -p /var/run/puppetlabs/${realname}
-        chown -R $USER:$GROUP /var/run/puppetlabs/${realname}
-    fi
+    /usr/bin/install --directory --owner=${GROUP} --group=${GROUP} --mode=775 /var/run/puppetlabs/${realname}
     [ -n "$pid" ] && echo $pid > $PIDFILE
 }
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake.tmpfiles.conf.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake.tmpfiles.conf.erb
@@ -1,1 +1,1 @@
-d /var/run/puppetlabs/<%= EZBake::Config[:project] %> 0755 <%= EZBake::Config[:user] %> <%= EZBake::Config[:group] %> -
+d /var/run/puppetlabs/<%= EZBake::Config[:real_name] %> 0755 <%= EZBake::Config[:user] %> <%= EZBake::Config[:group] %> -

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -173,7 +173,7 @@ function task_install {
     ln -s "../apps/${real_name}/bin/<%= basename %>" "${DESTDIR}${symbindir}/<%= basename %>"
     ln -s "../server/apps/${real_name}/bin/<%= basename %>" "${DESTDIR}${uxbindir}/<%= basename %>"
 <% end -%>
-    install -d -m 0755 "${DESTDIR}${rundir}"
+    install -d -m 0755 -o <%= EZBake::Config[:user] %> -g <%= EZBake::Config[:group] %> "${DESTDIR}${rundir}"
     install -d -m 700 "${DESTDIR}${app_logdir}"
 <% EZBake::Config[:create_dirs].each do |dir| -%>
     install -d -m 700 "${DESTDIR}<%= dir %>"
@@ -249,7 +249,7 @@ function task_sysv_init_deb {
     task defaults_deb
     install -d -m 0755 "${DESTDIR}${initdir}"
     install -m 0755 ext/debian/<%= EZBake::Config[:project] %>.init_script "${DESTDIR}${initdir}/<%= EZBake::Config[:project] %>"
-    install -d -m 0755 "${DESTDIR}${rundir}"
+    install -d -m 0755 -o <%= EZBake::Config[:user] %> -g <%= EZBake::Config[:group] %> "${DESTDIR}${rundir}"
 }
 
 # Install the systemd and defaults configuration for Debian.

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -32,6 +32,8 @@ fi
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 NAME=<%= EZBake::Config[:project] %>
 REALNAME=<%= EZBake::Config[:real_name] %>
+USER=<%= EZBake::Config[:user] %>
+GROUP=<%= EZBake::Config[:group] %>
 DESC="<%= EZBake::Config[:project] %> Puppet Labs version-checking backend"
 JARFILE="<%= EZBake::Config[:uberjar_name] %>"
 PIDFILE=/var/run/puppetlabs/${REALNAME}/${REALNAME}.pid
@@ -61,6 +63,8 @@ do_start()
     <% EZBake::Config[:debian][:pre_start_action].each do |action| -%>
     <%= action %>
     <% end -%>
+
+    /usr/bin/install --directory --owner=${GROUP} --group=${GROUP} --mode=775 /var/run/puppetlabs/${REALNAME}
 
     start-stop-daemon --start --quiet --chuid $USER --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR \
       --startas "${INSTALL_DIR}/bin/${REALNAME}" -- start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -48,10 +48,7 @@ START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 
 find_my_pid() {
     pid=`pgrep -f "${JARFILE}"`
-    if [ ! -d  "/var/run/puppetlabs/${realname}" ] ; then
-        mkdir -p /var/run/puppetlabs/${realname}
-        chown -R $USER:$GROUP /var/run/puppetlabs/${realname}
-    fi
+    /usr/bin/install --directory --owner=${GROUP} --group=${GROUP} --mode=775 /var/run/puppetlabs/${realname}
     [ -n "$pid" ] && echo $pid > $PIDFILE
 }
 


### PR DESCRIPTION
Prior to this commit, we had been creating the rundir, but with
incorrect permissions. This wasn't an issue for sysv systems, but it's
starting to crop up at a problem for systemd systems. This commit
ensures the rundir is created with the correct directory owner.