### PR TITLE
(EZ-103) Address incorrect rundir perms

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/ezbake.init.erb
@@ -32,6 +32,8 @@ fi
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 NAME=<%= EZBake::Config[:project] %>
 REALNAME=<%= EZBake::Config[:real_name] %>
+USER=<%= EZBake::Config[:user] %>
+GROUP=<%= EZBake::Config[:group] %>
 DESC="<%= EZBake::Config[:project] %> Puppet Labs version-checking backend"
 JARFILE="<%= EZBake::Config[:uberjar_name] %>"
 PIDFILE=/var/run/puppetlabs/${REALNAME}/${REALNAME}.pid
@@ -62,6 +64,7 @@ do_start()
     <%= action %>
     <% end -%>
 
+    /usr/bin/install --directory --owner=${USER} --group=${GROUP} --mode=755 "/var/run/puppetlabs/${REALNAME}"
     start-stop-daemon --start --quiet --chuid $USER --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR \
       --startas "${INSTALL_DIR}/bin/${REALNAME}" -- start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1
     retval=$?

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -48,10 +48,7 @@ START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 
 find_my_pid() {
     pid=`pgrep -f "${JARFILE}"`
-    if [ ! -d  "/var/run/puppetlabs/${realname}" ] ; then
-        mkdir -p /var/run/puppetlabs/${realname}
-        chown -R $USER:$GROUP /var/run/puppetlabs/${realname}
-    fi
+    /usr/bin/install --directory --owner=${USER} --group=${GROUP} --mode=755 "/var/run/puppetlabs/${realname}"
     [ -n "$pid" ] && echo $pid > $PIDFILE
 }
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -7,21 +7,29 @@ restartfile="/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/resta
 start_timeout="${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}"
 
 realname="<%= EZBake::Config[:real_name] %>"
-PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
+rundir="/var/run/puppetlabs/${realname}"
+PIDFILE="${rundir}/${realname}.pid"
 
 if [ ! -e "${INSTALL_DIR}/ezbake-functions.sh" ]; then
     echo "Unable to find ${INSTALL_DIR}/ezbake-functions.sh script, failing start." 1>&2
     exit 1
 fi
 
+/usr/bin/install --directory --owner=$USER --group=$GROUP --mode=755 "$rundir"
+if [ $? -ne 0 ]; then
+    echo "Unable to create/set permissions for rundir: ${rundir}" 1>&2
+    exit 1
+fi
+
 . "${INSTALL_DIR}/ezbake-functions.sh"
 
 write_pid_file() {
-    if [ ! -d "/var/run/puppetlabs/${realname}" ]; then
-        mkdir -p /var/run/puppetlabs/${realname}
-        chown -R $USER:$GROUP /var/run/puppetlabs/${realname}
+    echo "$pid" > "$PIDFILE"
+    if [ $? -ne 0 ]; then
+        echo "Unable to write pid file: ${PIDFILE}" 1>&2
+        terminate_java_process
+        exit 1
     fi
-    echo $1 > $PIDFILE
 }
 
 terminate_java_process() {
@@ -31,7 +39,7 @@ terminate_java_process() {
 }
 
 if [ -n "$pid" ]; then
-    write_pid_file $pid
+    write_pid_file
     exit 0
 fi
 
@@ -50,7 +58,7 @@ ${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=/dev/urandom \
 # $! is the process id of the last backgrounded process, the Java process above.
 pid=$!
 trap terminate_java_process SIGHUP SIGINT SIGTERM
-write_pid_file $pid
+write_pid_file
 
 cur="$(head -n 1 "$restartfile")"
 initial="$cur"
@@ -76,5 +84,5 @@ while [ "$cur" == "$initial" ] ;do
     fi
 done
 
-write_pid_file $pid
+write_pid_file
 exit 0

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake-functions.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake-functions.sh.erb
@@ -120,17 +120,10 @@ init_restart_file()
     local group="${GROUP:-<%= EZBake::Config[:group] %>}"
 
     if [ ! -e "$restartfile" ]; then
-        if [ ! -d "$restart_file_base_dir" ]; then
-            mkdir -p "$restart_file_base_dir"
-            if [ $? -ne 0 ]; then
-                echo "Unable to create base directory for restart file at ${restart_file_base_dir}" 1>&2
-                return 1
-            fi
-            chown $user:$group "$restart_file_base_dir"
-            if [ $? -ne 0 ]; then
-                echo "Unable to set permissions for base directory of restart file at ${restart_file_base_dir}" 1>&2
-                return 1
-            fi
+        /usr/bin/install --directory --owner=$user --group=$group --mode=755 "$restart_file_base_dir"
+        if [ $? -ne 0 ]; then
+            echo "Unable to create or set permissions for restart file at ${restart_file_base_dir}" 1>&2
+            return 1
         fi
         echo -n "0" > "$restart_file"
         if [ $? -ne 0 ]; then

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake.tmpfiles.conf.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake.tmpfiles.conf.erb
@@ -1,1 +1,1 @@
-d /var/run/puppetlabs/<%= EZBake::Config[:project] %> 0755 <%= EZBake::Config[:user] %> <%= EZBake::Config[:group] %> -
+d /var/run/puppetlabs/<%= EZBake::Config[:real_name] %> 0755 <%= EZBake::Config[:user] %> <%= EZBake::Config[:group] %> -

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -323,6 +323,8 @@ function task_postinst_permissions {
     chmod 770 $app_data
     chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> $projconfdir
     chmod 750 $projconfdir
+    chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> $rundir
+    chmod 0755 $rundir
 <% EZBake::Config[:create_dirs].each do |dir| -%>
     chown <%= EZBake::Config[:user] %>:<%= EZBake::Config[:group] %> <%= dir %>
     chmod 700 <%= dir %>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/ezbake.init.erb
@@ -32,6 +32,8 @@ fi
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 NAME=<%= EZBake::Config[:project] %>
 REALNAME=<%= EZBake::Config[:real_name] %>
+USER=<%= EZBake::Config[:user] %>
+GROUP=<%= EZBake::Config[:group] %>
 DESC="<%= EZBake::Config[:project] %> Puppet Labs version-checking backend"
 JARFILE="<%= EZBake::Config[:uberjar_name] %>"
 PIDFILE=/var/run/puppetlabs/${REALNAME}/${REALNAME}.pid
@@ -62,6 +64,7 @@ do_start()
     <%= action %>
     <% end -%>
 
+    /usr/bin/install --directory --owner=$USER --group=$GROUP --mode=755 "/var/run/puppetlabs/${REALNAME}"
     start-stop-daemon --start --quiet --chuid $USER --oknodo --pidfile $PIDFILE --chdir $INSTALL_DIR \
       --startas "${INSTALL_DIR}/bin/${REALNAME}" -- start >> /var/log/puppetlabs/${REALNAME}/${REALNAME}-daemon.log 2>&1
     retval=$?

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -48,10 +48,7 @@ START_TIMEOUT=${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}
 
 find_my_pid() {
     pid=`pgrep -f "${JARFILE}"`
-    if [ ! -d  "/var/run/puppetlabs/${realname}" ] ; then
-        mkdir -p /var/run/puppetlabs/${realname}
-        chown -R $USER:$GROUP /var/run/puppetlabs/${realname}
-    fi
+    /usr/bin/install --directory --owner=${USER} --group=${GROUP} --mode=755 "/var/run/puppetlabs/${realname}"
     [ -n "$pid" ] && echo $pid > $PIDFILE
 }
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -72,6 +72,7 @@ start() {
 
     export HOME="$(getent passwd ${USER} | cut -d':' -f6)"
 
+    /usr/bin/install --directory --owner=$USER --group=$GROUP --mode=755 "/var/run/puppetlabs/${realname}"
     # startproc will change users, so make sure that user has permission
     # to access the present working directory.
     cd "${INSTALL_DIR}"


### PR DESCRIPTION
Prior to this commit, we had been creating the rundir, but sometimes
with permissions which prevented the service from being able to create
its own pidfile.  In these cases, the Java process could be launched
successfully and the service start command could still return success.
Any subsequent attempts to ask the service framework for status on the
service, however, would return failure (not started).

This commit should ensure that the rundir is always created with
permissions which allow the service to create its own pidfile.  This
commit also adds some error handling to return failure at service
startup if the pidfile unexpectedly could not be written for some
reason.