### PR TITLE
(EZ-104) Restore missing oom command line argument

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -48,6 +48,7 @@ rm -f "$PIDFILE"
 init_restart_file "$restartfile" || exit $?
 
 ${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=/dev/urandom \
+  -XX:OnOutOfMemoryError="kill -9 %p" \
   -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> \
   clojure.main \
   -m <%= EZBake::Config[:main_namespace] %> \


### PR DESCRIPTION
This commit restores the -XX:OnOutOfMemoryError / kill -9 command line
argument to the Java command line in the start script.  This was
previously unintentionally lost in the conversion of the Java command
line construction from the init scripts and systemd service definitions
over to the start script.