### PR TITLE
(EZ-102) Update EZBake to install SysV + SystemD

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/postinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/postinst.erb
@@ -4,7 +4,7 @@
 
 # On upgrade, we should restart the service if it's running
 if [ $1 = 'configure' -a -n $2 ] ; then
-  if [ -d /run/systemd/system ]; then
+  if [ -d '/run/systemd/system' ] ; then
     # Using systemd
     systemctl daemon-reload >/dev/null 2>&1 || :
     systemctl try-restart <%= EZBake::Config[:project] %>.service ||:

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/postinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/postinst.erb
@@ -4,12 +4,8 @@
 
 # On upgrade, we should restart the service if it's running
 if [ $1 = 'configure' -a -n $2 ] ; then
-  if [ -e "/lib/systemd/system/<%= EZBake::Config[:project] -%>.service" ] ; then
+  if [ -d /run/systemd/system ]; then
     # Using systemd
-    if [ -e '/etc/init.d/<%= EZBake::Config[:project] %>' ] ; then
-      # We need to clean up the old sysv files if they still exist
-      rm '/etc/init.d/<%= EZBake::Config[:project] %>'
-    fi
     systemctl daemon-reload >/dev/null 2>&1 || :
     systemctl try-restart <%= EZBake::Config[:project] %>.service ||:
   else

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/prerm.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/prerm.erb
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$1" = "failed-upgrade" ] || [ "$1" = "remove" ] ; then
-  if [ -e "/lib/systemd/system/<%= EZBake::Config[:project] -%>.service" ] ; then
+  if [ -d /run/systemd/system ]; then
     # Using systemd
     systemctl --no-reload disable <%= EZBake::Config[:project] -%>.service > /dev/null 2>&1 || :
     systemctl stop <%= EZBake::Config[:project] -%>.service > /dev/null 2>&1 || :

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/prerm.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/prerm.erb
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$1" = "failed-upgrade" ] || [ "$1" = "remove" ] ; then
-  if [ -d /run/systemd/system ]; then
+  if [ -d '/run/systemd/system' ] ; then
     # Using systemd
     systemctl --no-reload disable <%= EZBake::Config[:project] -%>.service > /dev/null 2>&1 || :
     systemctl stop <%= EZBake::Config[:project] -%>.service > /dev/null 2>&1 || :

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/rules.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/debian/rules.erb
@@ -8,7 +8,7 @@ export rubylibdir=/opt/puppetlabs/puppet/lib/ruby/vendor_ruby
 DIST := $(shell lsb_release -i | awk '{print tolower($$3)}')
 RELEASE := $(shell lsb_release -r | awk '{print $$2}')
 CODENAME := $(shell lsb_release -c | sed -n 's/^Codename:\s*\(.*\)$$/\1/p')
-SYSV_CODENAMES := squeeze wheezy lucid precise trusty jessie
+SYSV_CODENAMES := squeeze wheezy lucid precise trusty
 export DESTDIR=$(BUILD_ROOT)
 export prefix=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>
 export bindir=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -78,7 +78,12 @@ function task_service {
     elif [ "$OSFAMILY" = "Debian" ]; then
         unitdir=${unitdir_debian}
         defaultsdir=${defaultsdir_debian}
-        task install_source_deb
+        sysv_codenames=("squeeze" "wheezy" "lucid" "precise" "trusty" "jessie")
+        if $(echo ${sysv_codenames[@]} | grep -q $CODENAME) ; then
+            task install_source_deb_sysv
+        else
+            task install_source_deb_systemd
+        fi
     else
         echo "Unsupported platform, exiting ..."
         exit 1
@@ -105,12 +110,19 @@ function task_install_source_rpm_systemd {
     task postinst_permissions
 }
 
-# Source based install for Debian based setups
-function task_install_source_deb {
+# Source based install for Debian based + sysv setups
+function task_install_source_deb_sysv {
     task preinst_deb
     task install_deb
-    task defaults_deb
     task sysv_init_deb
+    task logrotate
+    task postinst_deb
+}
+
+# Source based install for Debian based + systemd setups
+function task_install_source_deb_systemd {
+    task preinst_deb
+    task install_deb
     task systemd_deb
     task logrotate
     task postinst_deb
@@ -232,15 +244,17 @@ function task_systemd_redhat {
     install -m 0644 ext/<%= EZBake::Config[:project] %>.tmpfiles.conf "${DESTDIR}${tmpfilesdir}/<%= EZBake::Config[:project] %>.conf"
 }
 
-# Install the sysv init scripts for Debian.
+# Install the sysv and defaults configuration for Debian.
 function task_sysv_init_deb {
+    task defaults_deb
     install -d -m 0755 "${DESTDIR}${initdir}"
     install -m 0755 ext/debian/<%= EZBake::Config[:project] %>.init_script "${DESTDIR}${initdir}/<%= EZBake::Config[:project] %>"
     install -d -m 0755 "${DESTDIR}${rundir}"
 }
 
-# Install the systemd configuration for Debian.
+# Install the systemd/sysv and defaults configuration for Debian.
 function task_systemd_deb {
+    task sysv_init_deb
     install -d -m 0755 "${DESTDIR}${unitdir_debian}"
     install -m 0644 ext/debian/<%= EZBake::Config[:project] %>.service_file "${DESTDIR}${unitdir_debian}/<%= EZBake::Config[:project] %>.service"
     install -d -m 0755 "${DESTDIR}${tmpfilesdir}"

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -78,7 +78,7 @@ function task_service {
     elif [ "$OSFAMILY" = "Debian" ]; then
         unitdir=${unitdir_debian}
         defaultsdir=${defaultsdir_debian}
-        sysv_codenames=("squeeze" "wheezy" "lucid" "precise" "trusty" "jessie")
+        sysv_codenames=("squeeze" "wheezy" "lucid" "precise" "trusty")
         if $(echo ${sysv_codenames[@]} | grep -q $CODENAME) ; then
             task install_source_deb_sysv
         else

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -78,12 +78,7 @@ function task_service {
     elif [ "$OSFAMILY" = "Debian" ]; then
         unitdir=${unitdir_debian}
         defaultsdir=${defaultsdir_debian}
-        sysv_codenames=("squeeze" "wheezy" "lucid" "precise" "trusty" "jessie")
-        if $(echo ${sysv_codenames[@]} | grep -q $CODENAME) ; then
-            task install_source_deb_sysv
-        else
-            task install_source_deb_systemd
-        fi
+        task install_source_deb
     else
         echo "Unsupported platform, exiting ..."
         exit 1
@@ -111,18 +106,11 @@ function task_install_source_rpm_systemd {
 }
 
 # Source based install for Debian based setups
-function task_install_source_deb_sysv {
+function task_install_source_deb {
     task preinst_deb
     task install_deb
+    task defaults_deb
     task sysv_init_deb
-    task logrotate
-    task postinst_deb
-}
-
-# Source based install for Debian based + systemd setups
-function task_install_source_deb_systemd {
-    task preinst_deb
-    task install_deb
     task systemd_deb
     task logrotate
     task postinst_deb
@@ -244,17 +232,15 @@ function task_systemd_redhat {
     install -m 0644 ext/<%= EZBake::Config[:project] %>.tmpfiles.conf "${DESTDIR}${tmpfilesdir}/<%= EZBake::Config[:project] %>.conf"
 }
 
-# Install the sysv and defaults configuration for Debian.
+# Install the sysv init scripts for Debian.
 function task_sysv_init_deb {
-    task defaults_deb
     install -d -m 0755 "${DESTDIR}${initdir}"
     install -m 0755 ext/debian/<%= EZBake::Config[:project] %>.init_script "${DESTDIR}${initdir}/<%= EZBake::Config[:project] %>"
     install -d -m 0755 "${DESTDIR}${rundir}"
 }
 
-# Install the systemd and defaults configuration for Debian.
+# Install the systemd configuration for Debian.
 function task_systemd_deb {
-    task defaults_deb
     install -d -m 0755 "${DESTDIR}${unitdir_debian}"
     install -m 0644 ext/debian/<%= EZBake::Config[:project] %>.service_file "${DESTDIR}${unitdir_debian}/<%= EZBake::Config[:project] %>.service"
     install -d -m 0755 "${DESTDIR}${tmpfilesdir}"

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/postinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/postinst.erb
@@ -4,7 +4,8 @@
 
 # On upgrade, we should restart the service if it's running
 if [ $1 = 'configure' -a -n $2 ] ; then
-  if [ -d /run/systemd/system ]; then
+  if [ -d '/run/systemd/system' ] ; then
+    # Using systemd
     systemctl daemon-reload >/dev/null 2>&1 || :
     systemctl try-restart <%= EZBake::Config[:project] %>.service ||:
   else

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/postinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/postinst.erb
@@ -4,12 +4,7 @@
 
 # On upgrade, we should restart the service if it's running
 if [ $1 = 'configure' -a -n $2 ] ; then
-  if [ -e "/lib/systemd/system/<%= EZBake::Config[:project] -%>.service" ] ; then
-    # Using systemd
-    if [ -e '/etc/init.d/<%= EZBake::Config[:project] %>' ] ; then
-      # We need to clean up the old sysv files if they still exist
-      rm '/etc/init.d/<%= EZBake::Config[:project] %>'
-    fi
+  if [ -d /run/systemd/system ]; then
     systemctl daemon-reload >/dev/null 2>&1 || :
     systemctl try-restart <%= EZBake::Config[:project] %>.service ||:
   else

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/prerm.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/prerm.erb
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$1" = "failed-upgrade" ] || [ "$1" = "remove" ] ; then
-  if [ -e "/lib/systemd/system/<%= EZBake::Config[:project] -%>.service" ] ; then
+  if [ -d /run/systemd/system ]; then
     # Using systemd
     systemctl --no-reload disable <%= EZBake::Config[:project] -%>.service > /dev/null 2>&1 || :
     systemctl stop <%= EZBake::Config[:project] -%>.service > /dev/null 2>&1 || :

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/prerm.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/prerm.erb
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$1" = "failed-upgrade" ] || [ "$1" = "remove" ] ; then
-  if [ -d /run/systemd/system ]; then
+  if [ -d '/run/systemd/system' ] ; then
     # Using systemd
     systemctl --no-reload disable <%= EZBake::Config[:project] -%>.service > /dev/null 2>&1 || :
     systemctl stop <%= EZBake::Config[:project] -%>.service > /dev/null 2>&1 || :

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/rules.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/debian/rules.erb
@@ -8,7 +8,7 @@ export rubylibdir=/opt/puppetlabs/puppet/lib/ruby/vendor_ruby
 DIST := $(shell lsb_release -i | awk '{print tolower($$3)}')
 RELEASE := $(shell lsb_release -r | awk '{print $$2}')
 CODENAME := $(shell lsb_release -c | sed -n 's/^Codename:\s*\(.*\)$$/\1/p')
-SYSV_CODENAMES := squeeze wheezy lucid precise trusty jessie
+SYSV_CODENAMES := squeeze wheezy lucid precise trusty
 export DESTDIR=$(BUILD_ROOT)
 export prefix=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>
 export bindir=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/bin


### PR DESCRIPTION
This commit updates EZBake to start installing sysv files on newer
systemd based debian-ish systems. The idea being that users should be
able to switch between the older and newer service management tools.
This is a behavior that has already been established in other packages
that are targeted at newer releases.

This commit also updates EZBake to provide native SystemD files for
Debian 8 Jessie. This had not previously been done because of concerns
over saving state on upgrade from SysV to SystemD. This is no longer a
concern.