### PR TITLE
(SERVER-1670) Stop autogenerating dependencies for RPM packages

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -81,6 +81,11 @@ Obsoletes:        <%=package-%> <= <%=version-%>-1
 Conflicts:        <%=package-%> <= <%=version-%>-1
 <% end %>
 
+# Don't run the automatic dependency generation, we should be explicitly
+# requiring what we need.
+AutoReq:          0
+AutoProv:         0
+
 BuildRequires:    ruby
 BuildRequires:    /usr/sbin/useradd
 %if %{_with_systemd}
@@ -101,6 +106,7 @@ Requires(postun): systemd
 %endif
 
 Requires:         %{open_jdk}
+Requires:         bash
 # net-tools is required for netstat usage in service unit file
 # See: https://tickets.puppetlabs.com/browse/SERVER-338
 Requires:         net-tools

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -76,6 +76,11 @@ Obsoletes:        <%=package-%> <= <%=version-%>-1
 Conflicts:        <%=package-%> <= <%=version-%>-1
 <% end %>
 
+# Don't run the automatic dependency generation, we should be explicitly
+# requiring what we need.
+AutoReq:          0
+AutoProv:         0
+
 BuildRequires:    puppet-agent
 BuildRequires:    /usr/sbin/useradd
 %if %{_with_systemd}
@@ -100,6 +105,7 @@ Requires(postun): systemd
 
 Requires:         pe-java
 Requires:         pe-puppet-enterprise-release
+Requires:         bash
 # net-tools is required for netstat usage in service unit file
 # See: https://tickets.puppetlabs.com/browse/SERVER-338
 Requires:         net-tools


### PR DESCRIPTION
Currently the generated RPM packages will automatically generate
a set of requirements based on the contents of the package. This
has become an issue with puppet-server 2.7.0, as adding gems
to the package inadvertently added a dependency on system ruby.

This adds 'AutoReq: 0' to the RPM specs to stop generating automatic
dependency information, and adds 'bash' as the only dependency
that was being automatically added that we still want.

This also adds 'AutoProv: 0' to stop generating a package 'provides'.
This should be unnecessary, but harmless and may save us some pain in
the future if we wind up shipping any shared libs in a package somewhere.