### PR TITLE
(CPR-401) Require 'which'

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -110,6 +110,7 @@ Requires:         bash
 # net-tools is required for netstat usage in service unit file
 # See: https://tickets.puppetlabs.com/browse/SERVER-338
 Requires:         net-tools
+Requires:         /usr/bin/which
 # procps is required for pgrep, used in several of the init scripts
 Requires:         procps
 <% EZBake::Config[:redhat][:additional_build_dependencies].each do |dep| %>

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/ezbake.spec.erb
@@ -109,6 +109,7 @@ Requires:         bash
 # net-tools is required for netstat usage in service unit file
 # See: https://tickets.puppetlabs.com/browse/SERVER-338
 Requires:         net-tools
+Requires:         /usr/bin/which
 # procps is required for pgrep, used in several of the init scripts
 Requires:         procps
 <% EZBake::Config[:redhat][:additional_build_dependencies].each do |dep| %>


### PR DESCRIPTION
We add the dependency specifically on '/usr/bin/which' to be flexible
with minimal installers which may provide functionality from different
packages.