### PR TITLE
(SERVER-1723) Use /dev/urandom for foreground subcommand

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
@@ -17,6 +17,7 @@ then
 fi
 
 COMMAND="${JAVA_BIN} ${JAVA_ARGS} ${LOG_APPENDER} \
+         -Djava.security.egd=/dev/urandom \
          -cp ${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %> \
          clojure.main -m <%= EZBake::Config[:main_namespace] %> \
          --config ${CONFIG} --bootstrap-config ${BOOTSTRAP_CONFIG} \


### PR DESCRIPTION
This commit adds -Djava.security.egd=/dev/urandom as an argument to the
Java command line for the foreground subcommand.  This argument was
already being used in the service start subcommand.  Performance for some
operations like SSL can be significantly faster with this option in
place so it seems like having this benefit when troubleshooting with the
foreground subcommand would be a good thing.