### PR TITLE
(SERVER-1742) Improve init script behavior for service stop timeouts

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/init.erb
@@ -99,8 +99,7 @@ stop() {
 }
 
 restart() {
-    stop
-    start
+    stop && start
 }
 
 rh_status() {

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/stop.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/stop.erb
@@ -17,4 +17,5 @@ if [ -z "$pid" ]; then
     exit 0
 else
     kill_pid "$pid" "$PIDFILE" "$SERVICE_STOP_RETRIES"
+    exit $?
 fi

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake-functions.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake-functions.sh.erb
@@ -97,6 +97,12 @@ kill_pid()
         kill -KILL $pid >/dev/null 2>&1
         sleep 1
         kill -0 $pid >/dev/null 2>&1
+        timeout=$stop_timeout
+        while [ $? -eq 0 ] && [ $timeout -ne 0 ]; do
+            sleep 1
+            ((timeout--))
+            kill -0 $pid >/dev/null 2>&1
+        done
         if [ $? -eq 0 ]; then
             echo "Process $pid not killed after SIGKILL" 1>&2
             return 1

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.erb
@@ -99,8 +99,7 @@ stop() {
 }
 
 restart() {
-    stop
-    start
+    stop && start
 }
 
 rh_status() {

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/redhat/init.suse.erb
@@ -110,8 +110,7 @@ stop() {
 }
 
 restart() {
-    stop
-    start
+    stop && start
 }
 
 sl_status_q() {


### PR DESCRIPTION
Currently, the SysV init script 'restart' command will try to start the service even if the stop did not successfully complete.

This updates the service stop command to use the stop timeout value in the 'kill' signal in addition to the 'term' signal, and updates the init scripts to only attempt to start the service if the stop completes successfully in a 'restart'