### PR TITLE
(SERVER-1763) Add ca-certificates as build dependency

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb
@@ -27,6 +27,7 @@
 %global _systemd_sles  0
 %global _old_el        0
 %global _sles          0
+%global _certs_package  ca-certificates
 
 %if 0%{?fedora} >= 18 || 0%{?rhel} >= 7
 %global _with_systemd 1
@@ -35,10 +36,11 @@
 
 # We do not support any sles version less than 12, as there is not a sufficient
 # version of OpenJDK available to test against.
-%if 0%{?suse_version} >= 1210
-%global _with_systemd 1
-%global _systemd_sles 1
-%global _sles         1
+%if 0%{?suse_version}   >= 1210
+%global _with_systemd   1
+%global _systemd_sles   1
+%global _sles           1
+%global _certs_package  ca-certificates-mozilla
 %endif
 
 %if 0%{?rhel} && 0%{?rhel} < 7
@@ -94,6 +96,9 @@ BuildRequires:    systemd
 %if %{_old_el}
 Requires:         chkconfig
 %endif
+
+# Required to get trustanchors for java
+BuildRequires: %{_certs_package}
 
 %if %{_systemd_el}
 Requires(post):   systemd


### PR DESCRIPTION
Now that puppetserver has started bundling gems into the ezbake build,
java's lack of truststore anchors in our build has become a problem. In
jruby, simply requiring openssl will fail if there are no trust anchors.
This is the case on sles12. To avoid this problem, this commit adds the
correct ca-certificates package for el and for sles 12.