### PR TITLE
(RE-8694) Add `platform_repos` entry to build_defaults

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -17,3 +17,20 @@ build_ips: FALSE
 apt_host: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'
 apt_repo_path: '/opt/repository/incoming'
+platform_repos:
+  - name: el-6-i386
+    repo_location: repos/el/6/**/i386
+  - name: el-7-x86_64
+    repo_location: repos/el/7/**/x86_64
+  - name: sles-12-x86_64
+    repo_location: repos/sles/12/**/x86_64
+  - name: debian-7-i386
+    repo_location: repos/apt/wheezy
+  - name: debian-8-i386
+    repo_location: repos/apt/jessie
+  - name: ubuntu-12.04-i386
+    repo_location: repos/apt/precise
+  - name: ubuntu-14.04-i386
+    repo_location: repos/apt/trusty
+  - name: ubuntu-16.04-i386
+    repo_location: repos/apt/xenial

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -2,7 +2,7 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 default_cow: 'base-trusty-i386.cow'
-cows: 'base-jessie-i386.cow base-precise-i386.cow base-trusty-i386.cow base-wheezy-i386.cow base-wily-i386.cow base-xenial-i386.cow'
+cows: 'base-jessie-i386.cow base-precise-i386.cow base-trusty-i386.cow base-wheezy-i386.cow base-xenial-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_key: '7F438280EF8D349F'

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
@@ -17,3 +17,18 @@ build_ips: FALSE
 apt_host: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'
 apt_repo_path: '/opt/repository/incoming'
+platform_repos:
+  - name: el-6-x86_64
+    repo_location: repos/el/6/**/x86_64
+  - name: el-7-x86_64
+    repo_location: repos/el/7/**/x86_64
+  - name: sles-11-x86_64
+    repo_location: repos/sles/11/**/x86_64
+  - name: sles-12-x86_64
+    repo_location: repos/sles/12/**/x86_64
+  - name: ubuntu-12.04-amd64
+    repo_location: repos/apt/precise
+  - name: ubuntu-14.04-amd64
+    repo_location: repos/apt/trusty
+  - name: ubuntu-16.04-amd64
+    repo_location: repos/apt/xenial


### PR DESCRIPTION
This commit adds a `platform_repos` entry to build_defaults.yaml, similar to the one in puppet-agent. When built, this info will get put into the \<ref\>.yaml file created by packaging, which can then be used by beaker for testing.