### PR TITLE
(EZ-108) Don't deploy if `EZBAKE_NODEPLOY` set

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,13 @@ lein with-profile ezbake ezbake stage
 ```
 
 This will create an ephemeral git repository at `./target/staging` with staged
-templates ready for consumption by the build step.
+templates ready for consumption by the build step. If the project being staged
+has a SNAPSHOT version, then a snapshot build will be deployed to the project's
+configured snapshots repository (typically our internal nexus repository
+server at `nexus.delivery.puppetlabs.net`), in order to ensure our builds are
+reproducible. This can be avoided by setting the `EZBAKE_NODEPLOY` environment
+variable to any value. (If you set this environment variable in a build
+pipeline, you will be severely punished by the Angel of Build Reproducibility.)
 
 #### `build`
 

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -526,7 +526,8 @@ Dependency tree:
   ;; note that the `lein-project` arg gets shadowed a few lines down to add full
   ;; snapshot versions of dependencies
   [_ lein-project build-target]
-  (let [deployed-version (if (deputils/snapshot-version? (:version lein-project))
+  (let [deployed-version (if (and (deputils/snapshot-version? (:version lein-project))
+                                  (not (System/getenv "EZBAKE_NODEPLOY")))
                            (deploy-snapshot lein-project)
                            (:version lein-project))
         lein-project (update lein-project :dependencies (partial deputils/expand-snapshot-versions


### PR DESCRIPTION
Change the `stage` action to avoid deploying to the snapshots repository
if the `EZBAKE_NODEPLOY` environment variable is set to any value
(including `false` or `0` or `null`), and mention this in the README