### PR TITLE
(maint) Backport Snapshot-Version Changes & Full Dependency Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,13 +156,22 @@ lein with-profile ezbake ezbake stage
 ```
 
 This will create an ephemeral git repository at `./target/staging` with staged
-templates ready for consumption by the build step. If the project being staged
-has a SNAPSHOT version, then a snapshot build will be deployed to the project's
-configured snapshots repository (typically our internal nexus repository
-server at `nexus.delivery.puppetlabs.net`), in order to ensure our builds are
-reproducible. This can be avoided by setting the `EZBAKE_NODEPLOY` environment
-variable to any value. (If you set this environment variable in a build
-pipeline, you will be severely punished by the Angel of Build Reproducibility.)
+templates ready for consumption by the build step.
+
+If the project being staged has a SNAPSHOT version, then a snapshot build will
+be deployed to the project's configured snapshots repository (typically our
+internal nexus repository server at `nexus.delivery.puppetlabs.net`), in order
+to ensure our builds are reproducible. This can be avoided by setting the
+`EZBAKE_NODEPLOY` environment variable to any value.
+
+If the project or any of its dependencies have a SNAPSHOT version, but
+a deployed snapshot artifact matching that version cannot be found in the
+configured repositories (for example, because they have only been installed
+locally), then EZBake will throw an error to prevent an unreproducible build. If
+you're testing local changes, you can avoid this check by setting the
+`EZBAKE_ALLOW_UNREPRODUCIBLE_BUILDS` environment variable to any value. (If you
+set this in a build pipeline, bad things will happen, possible to a future
+version of yourself.)
 
 #### `build`
 
@@ -410,7 +419,7 @@ on the application, followed by calling `start` on the application.  When the
 `restart-file` on disk.  The reload script polls in a loop for the contents of
 the `restart-file`.  When the contents have changed, the reload script
 determines that the reload is successful and the script returns.  For more
-information on the `restart-file` feature in Trapperkeeper, see 
+information on the `restart-file` feature in Trapperkeeper, see
 ![this page](https://github.com/puppetlabs/trapperkeeper/blob/1.5.1/documentation/Restart-File.md)
 in the Trapperkeeper documentation.
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,13 @@ lein with-profile ezbake ezbake stage
 ```
 
 This will create an ephemeral git repository at `./target/staging` with staged
-templates ready for consumption by the build step.
+templates ready for consumption by the build step. If the project being staged
+has a SNAPSHOT version, then a snapshot build will be deployed to the project's
+configured snapshots repository (typically our internal nexus repository
+server at `nexus.delivery.puppetlabs.net`), in order to ensure our builds are
+reproducible. This can be avoided by setting the `EZBAKE_NODEPLOY` environment
+variable to any value. (If you set this environment variable in a build
+pipeline, you will be severely punished by the Angel of Build Reproducibility.)
 
 #### `build`
 

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -523,10 +523,14 @@ Dependency tree:
   (fn [action & args] action))
 
 (defmethod action "stage"
+  ;; note that the `lein-project` arg gets shadowed a few lines down to add full
+  ;; snapshot versions of dependencies
   [_ lein-project build-target]
   (let [deployed-version (if (deputils/snapshot-version? (:version lein-project))
                            (deploy-snapshot lein-project)
-                           (:version lein-project))]
+                           (:version lein-project))
+        lein-project (update lein-project :dependencies (partial deputils/expand-snapshot-versions
+                                                                 lein-project))]
     (let [template-dir (get-template-file build-target)
           uberjar-name (:uberjar-name lein-project)]
       (uberjar/uberjar lein-project)

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -526,7 +526,8 @@ Dependency tree:
   ;; note that the `lein-project` arg gets shadowed a few lines down to add full
   ;; snapshot versions of dependencies
   [_ lein-project build-target]
-  (let [deployed-version (if (deputils/snapshot-version? (:version lein-project))
+  (let [deployed-version (if (and (deputils/snapshot-version? (:version lein-project))
+                                  (not (System/getenv "EZBAKE_NODEPLOY")))
                            (deploy-snapshot lein-project)
                            (:version lein-project))
         lein-project (update lein-project :dependencies (partial deputils/expand-snapshot-versions

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -7,6 +7,7 @@
             [clj-time.local :as local-time]
             [stencil.core :as stencil]
             [leiningen.core.main :as lein-main]
+            [leiningen.deploy :as deploy]
             [leiningen.uberjar :as uberjar]
             [schema.core :as schema]
             [schema.utils :as schema-utils]
@@ -286,6 +287,17 @@ Dependency tree:
         (deputils/cp-files-of-type lein-project "doc"
                                    docs-prefix get-out-dir-for-doc-file)))
 
+(defn deploy-snapshot
+  "Given a project map with a snapshot version, deploy to the configured
+  snapshots repository and return the version of the deployed artifact. If given
+  a map with a non-snapshot version, does nothing and returns nil."
+  [lein-project]
+  (when (deputils/snapshot-version? (:version lein-project))
+    (-> (deploy/deploy lein-project)
+      .getArtifacts
+      (nth 0)
+      .getVersion)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Upstream EZBake config handling
 
@@ -512,43 +524,43 @@ Dependency tree:
 
 (defmethod action "stage"
   [_ lein-project build-target]
-  (lein-main/info "Running 'lein install' to pick up local changes.")
-  (let [result (exec/exec "lein" "install")]
-    (lein-main/info (:out result))
-    (lein-main/info (:err result)))
-  (let [template-dir (get-template-file build-target)
-        uberjar-name (:uberjar-name lein-project)]
-    (uberjar/uberjar lein-project)
-    (fs/copy+ (format "%s/%s" "target" uberjar-name)
-              (format "%s/%s" staging-dir uberjar-name))
-    (cp-template-files template-dir)
-    (cp-template-files (get-template-file "global")))
-  (let [dependencies    (deputils/get-dependencies-with-jars lein-project)
-        config-files    (cp-shared-files dependencies get-config-files-in)
-        config-files    (concat config-files  (cp-project-config-files lein-project))
-        system-config-files (cp-system-config-files lein-project)
-        _               (cp-shared-files dependencies get-cli-app-files-in)
-        cli-app-files   (->> (str/join "/" [staging-dir "ext" "cli"])
-                             fs/list-dir
-                             (map #(relativize staging-dir %)))
-        bin-files       (cp-shared-files dependencies get-bin-files-in)
-        terminus-files  (cp-terminus-files dependencies build-target)
-        upstream-ezbake-configs (get-upstream-ezbake-configs lein-project)]
-    (cp-shared-files dependencies get-build-scripts-files-in)
-    (if cli-app-files
-      (cp-cli-wrapper-scripts (:name lein-project)))
-    (cp-doc-files lein-project)
-    (generate-ezbake-config-file! lein-project
-                                  build-target
-                                  config-files
-                                  system-config-files
-                                  cli-app-files
-                                  bin-files
-                                  terminus-files
-                                  upstream-ezbake-configs)
-    (generate-project-data-yaml lein-project build-target)
-    (generate-manifest-file lein-project)
-    (create-git-repo lein-project)))
+  (let [deployed-version (if (deputils/snapshot-version? (:version lein-project))
+                           (deploy-snapshot lein-project)
+                           (:version lein-project))]
+    (let [template-dir (get-template-file build-target)
+          uberjar-name (:uberjar-name lein-project)]
+      (uberjar/uberjar lein-project)
+      (fs/copy+ (format "%s/%s" "target" uberjar-name)
+                (format "%s/%s" staging-dir uberjar-name))
+      (cp-template-files template-dir)
+      (cp-template-files (get-template-file "global")))
+    (let [dependencies    (deputils/get-dependencies-with-jars lein-project)
+          config-files    (cp-shared-files dependencies get-config-files-in)
+          config-files    (concat config-files  (cp-project-config-files lein-project))
+          system-config-files (cp-system-config-files lein-project)
+          _               (cp-shared-files dependencies get-cli-app-files-in)
+          cli-app-files   (->> (str/join "/" [staging-dir "ext" "cli"])
+                            fs/list-dir
+                            (map #(relativize staging-dir %)))
+          bin-files       (cp-shared-files dependencies get-bin-files-in)
+          terminus-files  (cp-terminus-files dependencies build-target)
+          upstream-ezbake-configs (get-upstream-ezbake-configs lein-project)]
+      (cp-shared-files dependencies get-build-scripts-files-in)
+      (if cli-app-files
+        (cp-cli-wrapper-scripts (:name lein-project)))
+      (cp-doc-files lein-project)
+      (generate-ezbake-config-file! lein-project
+                                    build-target
+                                    config-files
+                                    system-config-files
+                                    cli-app-files
+                                    bin-files
+                                    terminus-files
+                                    upstream-ezbake-configs)
+      (let [project-w-deployed-version (assoc lein-project :version deployed-version)]
+        (generate-project-data-yaml project-w-deployed-version build-target)
+        (generate-manifest-file project-w-deployed-version))
+      (create-git-repo lein-project))))
 
 (defmethod action "build"
   [_ lein-project build-target]

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -530,8 +530,10 @@ Dependency tree:
                                   (not (System/getenv "EZBAKE_NODEPLOY")))
                            (deploy-snapshot lein-project)
                            (:version lein-project))
-        lein-project (update lein-project :dependencies (partial deputils/expand-snapshot-versions
-                                                                 lein-project))]
+        reproducible? (not (System/getenv "EZBAKE_ALLOW_UNREPRODUCIBLE_BUILDS"))
+        lein-project (update lein-project :dependencies
+                             #(deputils/expand-snapshot-versions
+                                lein-project % {:reproducible? reproducible?}))]
     (let [template-dir (get-template-file build-target)
           uberjar-name (:uberjar-name lein-project)]
       (uberjar/uberjar lein-project)

--- a/src/puppetlabs/ezbake/dependency_utils.clj
+++ b/src/puppetlabs/ezbake/dependency_utils.clj
@@ -228,7 +228,9 @@
 
 (defn generate-manifest-string
   [lein-project]
-  (let [deps (get-relevant-deps lein-project)]
+  (let [deps (concat [[(symbol (:group lein-project) (:name lein-project))
+                       (:version lein-project)]]
+               (get-relevant-deps lein-project))]
     (str/join "," (map get-manifest-string deps))))
 
 (defn generate-dependency-tree-string

--- a/src/puppetlabs/ezbake/dependency_utils.clj
+++ b/src/puppetlabs/ezbake/dependency_utils.clj
@@ -214,3 +214,7 @@
                     out-dir-fn
                     lein-project)
            deps))))
+
+(defn snapshot-version?
+  [version]
+  (boolean (re-find #"-SNAPSHOT$" version)))

--- a/src/puppetlabs/ezbake/dependency_utils.clj
+++ b/src/puppetlabs/ezbake/dependency_utils.clj
@@ -138,7 +138,7 @@
 
 (defn get-manifest-string
   [dep]
-  (format "%s %s" (name (first dep)) (second dep)))
+  (format "%s %s" (str (first dep)) (second dep)))
 
 (defn add-dep-hierarchy-to-string!
   [deps-map sb depth]


### PR DESCRIPTION
Backport the recently merged changes on master to list specific snapshot versions included in a package and to have the full dependency symbol (including the group) in the description.