### PR TITLE
(RE-8726) Allow nonfinal repo definition

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
@@ -60,7 +60,9 @@ tar_excludes:
   - .gitignore
 build_pe: {{{is-pe-build}}}
 apt_repo_name: {{{repo-name}}}
+apt_nonfinal_repo_name: {{{nonfinal-repo-name}}}
 yum_repo_name: {{{repo-name}}}
+yum_nonfinal_repo_name: {{{nonfinal-repo-name}}}
 gem_files:
 gem_require_path:
 gem_test_files:

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -58,6 +58,7 @@
    (schema/optional-key :build-type) schema/Str
    (schema/optional-key :reload-timeout) schema/Int
    (schema/optional-key :repo-target) schema/Str
+   (schema/optional-key :nonfinal-repo-target) schema/Str
    (schema/optional-key :replaces-pkgs) ReplacesPkgs
    (schema/optional-key :start-after) [schema/Str]
    (schema/optional-key :start-timeout) schema/Int
@@ -558,7 +559,8 @@ Additional uberjar dependencies:
        :uberjar-name (:uberjar-name lein-project)
        :additional-uberjars (mapv (fn [filename] {:uberjar filename}) additional-uberjars)
        :is-pe-build (format "%s" (= (get-local-ezbake-var lein-project :build-type "foss") "pe"))
-       :repo-name (format "%s" (get-local-ezbake-var lein-project :repo-target ""))})))
+       :repo-name (format "%s" (get-local-ezbake-var lein-project :repo-target ""))
+       :nonfinal-repo-name (format "%s" (get-local-ezbake-var lein-project :nonfinal-repo-target ""))})))
 
 (schema/defn get-additional-uberjars
   "Returns the list of additional uberjar dependencies from the given lein project"


### PR DESCRIPTION
This commit allows ezbake to take advantage of a new feature in the
packaging repo. We can switch between a final and non-final repo
definition. This commit allows ezbake to set a value for that non-final
repo and for that setting to propagate through properly to the
automation in the packaging repo.

This means we can ship development builds with the same automation we
use to ship final builds. But the builds will be kept separate based on
if it's a final or non-final build (determined by the presence of
SNAPSHOT in the version name).

This is all in preparation for the change over to the puppet5 repos.
Before we have all the finalized puppet5 packages, we want to make
beta/development/nightly builds available on apt.puppetlabs.com,
yum.puppetlabs.com, and downloads.puppetlabs.com under a separate repo
than the main packages.