### PR TITLE
(EZ-109) Fix duplicate text in ezbake.manifest

### DIFF
--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -196,7 +196,7 @@
          :manifest-string (deputils/generate-manifest-string lein-project)
          :dependency-tree (deputils/generate-dependency-tree-string lein-project)
          :additional-uberjar-info uberjar-info
-         :has-additional-uberjars (not-empty additional-uberjars-info)}]
+         :has-additional-uberjars (not (empty? additional-uberjars-info))}]
     (spit
      (fs/file staging-dir "ext" "ezbake.manifest")
      (stencil/render-string "


### PR DESCRIPTION
This commit fixes an issue where some duplicate text would show up in
ezbake.manifest if additional uberjars were specified in the ezbake section of
a project.clj file

This was because of a combination of mustache being mustache, and because
`not-empty` returns its argument if it is not empty, rather than returning true.
This causes the mustache template to act unexpectedly.

`(not (empty? ...))` always returns a boolean and fixes the issue