### PR TITLE
(EZ-110) Fix ezbake manifest generation for dependency overrides

### DIFF
--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -617,7 +617,13 @@ Additional uberjar dependencies:
   be deactivated.
 
   This function is heavily copied from the implementation of
-  leiningen.uberjar/uberjar."
+  leiningen.uberjar/uberjar, see:
+  https://github.com/technomancy/leiningen/blob/2.7.1/src/leiningen/uberjar.clj#L143-L187.
+  The main difference is that whereas the leiningen uberjar function builds a
+  new jar file for the immediate project artifact,
+  https://github.com/technomancy/leiningen/blob/2.7.1/src/leiningen/uberjar.clj#L167-L172,
+  this function uses the jar file passed in as an argument to this function
+  instead."
   [project jar]
   (let [scoped-profiles (set (project/pom-scope-profiles project :provided))
         default-profiles (set (project/expand-profile project :default))
@@ -626,7 +632,7 @@ Additional uberjar dependencies:
                            (-> project meta :included-profiles))
         project (project/merge-profiles
                  (project/merge-profiles project [:uberjar]) provided-profiles)
-        _ #_ (bail early if snapshot) (pom/check-for-snapshot-deps project)
+        _ (pom/check-for-snapshot-deps project) ;; bail early if snapshot
         project (update-in project [:jar-inclusions]
                            concat (:uberjar-inclusions project))
         standalone-filename (jar/get-jar-filename project :standalone)]

--- a/src/puppetlabs/ezbake/dependency_utils.clj
+++ b/src/puppetlabs/ezbake/dependency_utils.clj
@@ -64,6 +64,18 @@
 (defn expand-snapshot-version
   ([lein-project coords] (expand-snapshot-version lein-project coords {}))
   ([lein-project coords options]
+   ;; For cases where the -SNAPSHOT is expanded to a full version, the version
+   ;; portion of the coordinate (second element in the vector) is replaced but
+   ;; all other qualifying metadata in the coordinate, e.g., any :exclusions
+   ;; which might be present, is preserved.
+   ;;
+   ;; For example, if the original coordinate has:
+   ;;
+   ;;   ['foo "0.0.1-SNAPSHOT" :exclusions ['bar]]
+   ;;
+   ;; .. then the result after expansion might have:
+   ;;
+   ;;   ['foo "0.0.1-20170501.100101-123" :exclusions ['bar]]
    (assoc coords 1 (get-full-snapshot-version lein-project coords options))))
 
 (defn expand-snapshot-versions

--- a/src/puppetlabs/ezbake/dependency_utils.clj
+++ b/src/puppetlabs/ezbake/dependency_utils.clj
@@ -63,8 +63,8 @@
 
 (defn expand-snapshot-version
   ([lein-project coords] (expand-snapshot-version lein-project coords {}))
-  ([lein-project [dependency version :as coords] options]
-   [dependency (get-full-snapshot-version lein-project coords options)]))
+  ([lein-project coords options]
+   (assoc coords 1 (get-full-snapshot-version lein-project coords options))))
 
 (defn expand-snapshot-versions
   ([lein-project dependencies] (expand-snapshot-versions lein-project dependencies {}))


### PR DESCRIPTION
Previously, the additional uberjar functionality appended the immediate
project jar as a dependency of itself in order for its content to be
generated into the uberjar.  This logic, however, did not work when the
project had any dependency overrides in the uberjar profile.  In that
case, none of the content from the immediate jar ended up in the uberjar
and the ezbake.manifest dependency info errantly listed info from the
main project's dependencies which did not end up in the uberjar.

In this PR, the immediate project's jar is appended directly into
the process of creating the uberjar - rather than as a self-referential
dependency.  This allows for the uberjar to properly retain content from
the main project jar even in the case of uberjar profile overrides.  The
main project's own artifact info is also added to the dependency listing
info directly, avoiding the appearance of errant transitive dependency
info in the output in cases where dependency exclusions are used.

Also, work was previously done to expand SNAPSHOT versions to the version of
the actual artifact previously deployed to a repository.  In the process
of expansion, any qualifying info on the coordinate, e.g., any
exclusions, was lost.  The resulting uberjar which was built would still
honor the qualifying info, however, the ezbake.manifest would errantly
list info that should have been excluded per the qualifying coordinate
info.

In this PR, the SNAPSHOT expansion logic only updates the dependency
version field, leaving all other trailing coordinate info in place.
This enables the ezbake.manifest to accurately reflect the content
generated into the uberjar.