### PR TITLE
(RE-8457) Update ezbake to ship projects to puppet5

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
@@ -65,9 +65,11 @@ tar_excludes:
   - .gitignore
 build_pe: {{{is-pe-build}}}
 apt_repo_name: {{{repo-name}}}
-apt_nonfinal_repo_name: {{{nonfinal-repo-name}}}
 yum_repo_name: {{{repo-name}}}
-yum_nonfinal_repo_name: {{{nonfinal-repo-name}}}
+repo_name: {{{new-repo-name}}}
+repo_link_target: {{{repo-link-name}}}
+nonfinal_repo_name: {{{nonfinal-repo-name}}}
+nonfinal_repo_link_target: {{{nonfinal-repo-link-name}}}
 gem_files:
 gem_require_path:
 gem_test_files:

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -1,11 +1,12 @@
 ---
-packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=1.0.x'
 packaging_repo: 'packaging'
 default_cow: 'base-jessie-i386.cow'
 cows: 'base-jessie-i386.cow base-xenial-i386.cow base-stretch-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_key: '7F438280EF8D349F'
+gpg_nonfinal_key: 'B8F999C007BB6C57'
 sign_tar: FALSE
 # a space separated list of mock configs
 final_mocks: 'pl-el-6-i386 pl-el-7-x86_64 pl-sles-12-x86_64'

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
@@ -1,11 +1,12 @@
 ---
-packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=1.0.x'
 packaging_repo: 'packaging'
 default_cow: 'base-trusty-amd64.cow'
 cows: 'base-trusty-amd64.cow base-xenial-amd64.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppet'
 gpg_key: '7F438280EF8D349F'
+gpg_nonfinal_key: 'B8F999C007BB6C57'
 sign_tar: FALSE
 # a space separated list of mock configs
 final_mocks: 'pupent-el6-x86_64 pupent-el7-x86_64 pupent-sles11-x86_64 pupent-sles12-x86_64'

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -63,7 +63,10 @@
    (schema/optional-key :build-type) schema/Str
    (schema/optional-key :reload-timeout) schema/Int
    (schema/optional-key :repo-target) schema/Str
+   (schema/optional-key :new-repo-target) schema/Str
+   (schema/optional-key :repo-link-target) schema/Str
    (schema/optional-key :nonfinal-repo-target) schema/Str
+   (schema/optional-key :nonfinal-repo-link-target) schema/Str
    (schema/optional-key :replaces-pkgs) ReplacesPkgs
    (schema/optional-key :start-after) [schema/Str]
    (schema/optional-key :start-timeout) schema/Int
@@ -597,7 +600,10 @@ Additional uberjar dependencies:
        :additional-uberjars (mapv (fn [filename] {:uberjar filename}) additional-uberjars)
        :is-pe-build (format "%s" (= (get-local-ezbake-var lein-project :build-type "foss") "pe"))
        :repo-name (format "%s" (get-local-ezbake-var lein-project :repo-target ""))
+       :new-repo-name (format "%s" (get-local-ezbake-var lein-project :new-repo-target ""))
+       :repo-link-name (format "%s" (= (get-local-ezbake-var lein-project :repo-link-target "") "puppet"))
        :nonfinal-repo-name (format "%s" (get-local-ezbake-var lein-project :nonfinal-repo-target ""))})))
+       :nonfinal-repo-link-name (format "%s" (= (get-local-ezbake-var lein-project :nonfinal-repo-link-target "") "puppet-nightly"))
 
 (schema/defn get-additional-uberjars
   "Returns the list of additional uberjar dependencies from the given lein project"


### PR DESCRIPTION
This commit switches ezbake to use the 1.0.x branch of
puppetlabs/packaging, which contains all the updates we need to ship
packages to the new puppet5 and puppet5-nightly repos. This commit also
adds in the new variable `gpg_nonfinal_key`, which allows us to sign
nonfinal/development/beta/nightly builds with a separate key.