### PR TITLE
(RE-8861) Add managed dependencies to dependency map

### DIFF
--- a/src/puppetlabs/ezbake/dependency_utils.clj
+++ b/src/puppetlabs/ezbake/dependency_utils.clj
@@ -253,7 +253,7 @@
 (defn generate-dependency-map
   [lein-project]
   (aether/dependency-hierarchy
-   (:dependencies lein-project)
+    (concat (:dependencies lein-project) (:managed-dependencies lein-project))
    (aether/resolve-dependencies
     :coordinates (:dependencies lein-project)
     :managed-coordinates (:managed-dependencies lein-project)


### PR DESCRIPTION
Before this commit we were only listing the dependencies which were
listed in the dependencies field which may not include everything. This
commit adds the managed dependencies to the list of dependencies to
consider when building out the dependency map.