### PR TITLE
(maint) Move doc installation to install.sh

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -1,6 +1,7 @@
 module EZBake
   Config = {
       :project        => '{{{project}}}',
+      :version        => '{{{version}}}',
       :real_name      => '{{{real-name}}}',
       :user           => '{{{user}}}',
       :group          => '{{{group}}}',

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/docs.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/docs.erb
@@ -1,3 +1,0 @@
-<% if File.exists?("ext/docs") %>
-ext/docs
-<% end %>

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.spec.erb
@@ -284,9 +284,6 @@ fi
 <%- EZBake::Config[:create_dirs].each do |dir| -%>
 %dir %attr(0700, <%= EZBake::Config[:user] %>, <%= EZBake::Config[:group] %>) <%= dir %>
 <%- end -%>
-<% if File.exists?("ext/docs") -%>
-%doc ext/docs
-<% end -%>
 %{_app_prefix}
 %if %{_with_systemd}
 %{_unitdir}/%{name}.service

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -129,6 +129,22 @@ function task_install_source_deb_systemd {
     task postinst_deb
 }
 
+# install docs for debian based systems
+function task_install_docs_deb {
+  if [ -d ext/docs ]; then
+    install -d "${DESTDIR}${app_prefix}/share/doc/<%= EZBake::Config[:project] %>"
+    cp -a ext/docs "${DESTDIR}${app_prefix}/share/doc/<%= EZBake::Config[:project] %>"
+  fi
+}
+
+# install docs for rpm based systems
+function task_install_docs_rpm {
+  if [ -d ext/docs ]; then
+    install -d "${DESTDIR}${app_prefix}/share/doc/<%= EZBake::Config[:project] %>-<%= EZBake::Config[:version] %>"
+    cp -a ext/docs "${DESTDIR}${app_prefix}/share/doc/<%= EZBake::Config[:project] %>-<%= EZBake::Config[:version] %>"
+  fi
+}
+
 # Install the ezbake package software. This step is used during RPM &
 # Debian packaging during the 'install' phases.
 function task_install {
@@ -138,11 +154,6 @@ function task_install {
     install -m 0755 ext/ezbake-functions.sh "${dest_apps_dir}"
     install -m 0644 ext/ezbake.manifest "${dest_apps_dir}"
     install -d -m 0755 "${DESTDIR}${projconfdir}/conf.d"
-
-    if [ -d ext/docs ]; then
-      install -d "${DESTDIR}${app_prefix}/share/doc/<%= EZBake::Config[:project] %>-<%= EZBake::Config[:version] %>"
-      cp -a ext/docs "${DESTDIR}${app_prefix}/share/doc/<%= EZBake::Config[:project] %>-<%= EZBake::Config[:version] %>"
-    fi
 
 <% if EZBake::Config[:additional_uberjars]  -%>
   <% EZBake::Config[:additional_uberjars].each do |jar| -%>
@@ -199,6 +210,7 @@ fi
 
 function task_install_redhat {
     task install
+    task install_docs_rpm
 <% EZBake::Config[:redhat][:additional_install].each do |install| -%>
     <%= install %>
 <% end -%>
@@ -206,6 +218,7 @@ function task_install_redhat {
 
 function task_install_deb {
     task install
+    task install_docs_deb
 <% EZBake::Config[:debian][:additional_install].each do |install| -%>
     <%= install %>
 <% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -139,6 +139,11 @@ function task_install {
     install -m 0644 ext/ezbake.manifest "${dest_apps_dir}"
     install -d -m 0755 "${DESTDIR}${projconfdir}/conf.d"
 
+    if [ -d ext/docs ]; then
+      install -d "${DESTDIR}${app_prefix}/share/doc/<%= EZBake::Config[:project] %>-<%= EZBake::Config[:version] %>"
+      cp -a ext/docs "${DESTDIR}${app_prefix}/share/doc/<%= EZBake::Config[:project] %>-<%= EZBake::Config[:version] %>"
+    fi
+
 <% if EZBake::Config[:additional_uberjars]  -%>
   <% EZBake::Config[:additional_uberjars].each do |jar| -%>
     install -m 0644 <%= jar %> "${dest_apps_dir}"

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -476,6 +476,7 @@ Additional uberjar dependencies:
                                                       platform
                                                       variable)))]
     {:project                   (:name lein-project)
+     :version                   (:version lein-project)
      :real-name                 (get-real-name (:name lein-project))
      :user                      (get-local-ezbake-var lein-project :user
                                                       (:name lein-project))


### PR DESCRIPTION
As we start exploring alternate packaging with ezbake, it's cleaner if
we let the install script put the docs in place as we do with all the
other files rather than installing those separately.