### PR TITLE
(maint) Remove EOL ubuntu platforms from cow lists

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -2,7 +2,7 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 default_cow: 'base-trusty-i386.cow'
-cows: 'base-jessie-i386.cow base-precise-i386.cow base-trusty-i386.cow base-wheezy-i386.cow base-wily-i386.cow base-xenial-i386.cow'
+cows: 'base-jessie-i386.cow base-trusty-i386.cow base-wheezy-i386.cow base-xenial-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_key: '7F438280EF8D349F'

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
@@ -2,7 +2,7 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 default_cow: 'base-trusty-amd64.cow'
-cows: 'base-precise-amd64.cow base-trusty-amd64.cow base-xenial-amd64.cow'
+cows: 'base-trusty-amd64.cow base-xenial-amd64.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppet'
 gpg_key: '7F438280EF8D349F'


### PR DESCRIPTION
We still had precise and wily in our default cow list. We should remove
those, as both of those platforms are EOL.