### PR TITLE
(SERVER-249) Conditionally create directory for user JARs

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -52,7 +52,8 @@ module EZBake
                             "{{package}}" => "{{version}}",
                           {{/replaces-pkgs}}
                           },
-      :bootstrap_source => '{{{bootstrap-source}}}',
-      :logrotate_enabled => {{{logrotate-enabled}}}
+      :bootstrap_source  => '{{{bootstrap-source}}}',
+      :logrotate_enabled => {{{logrotate-enabled}}},
+      :create_jar_dir    => {{{create-jar-dir}}}
   }
 end

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -195,6 +195,10 @@ if [ -e "<%= EZBake::Config[:cli_defaults_file] %>" ]; then
     install -m 0755 <%= EZBake::Config[:cli_defaults_file] %> "${dest_apps_dir}/cli/"
 fi
 
+<% if EZBake::Config[:create_jar_dir] -%>
+  install -d -m 0755 "${app_data}/jars"
+<% end -%>
+
 <% EZBake::Config[:bin_files].each do |bin_file| -%>
     install -m 0755 <%= bin_file %> "${DESTDIR}${bindir}"
     <% basename = File.basename(bin_file) -%>

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -524,6 +524,7 @@ Additional uberjar dependencies:
                                                             :bootstrap-cfg))
      :logrotate-enabled         (get-local-ezbake-var lein-project :logrotate-enabled
                                                       true)
+     :create-jar-dir            (get-local-ezbake-var lein-project :create-jar-dir false)
      :additional-uberjars       (quoted-list additional-uberjars)}))
 
 ;; TODO: this is wonky; we're basically doing some templating here and it


### PR DESCRIPTION
This commit creates a specific location for users to put arbitrary JARs
that they want loaded on the classpath when Puppetserver starts. It will
only be created if `create-jar-dir` is set to true in the project's
EZBake config.