### PR TITLE
(maint) Make sure the packaging tarball is shipped

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/tasks/build.rake
+++ b/resources/puppetlabs/lein-ezbake/template/global/tasks/build.rake
@@ -10,7 +10,7 @@ namespace :pl do
     nested_output = '../../../output'
     pkg_path = '../pkg'
     staging_path = 'pkg_artifacts'
-    FileUtils.mv(Dir.glob("pkg/*.gz").join(''), FileUtils.pwd)
+    FileUtils.cp(Dir.glob("pkg/*.gz").join(''), FileUtils.pwd)
     # unpack the tarball we made during the build step
     stdout, stderr, exitstatus = Pkg::Util::Execution.capture3(%(tar xf #{Dir.glob("*.gz").join('')}))
     Pkg::Util::Execution.success?(exitstatus) or raise "Error unpacking tarball: #{stderr}"


### PR DESCRIPTION
Initially we were generating the packaging tarball then moving it into a
staging directory to prepare artifacts for the build step. However, we
should be shipping this tarball to builds, so let's copy it instead.