### PR TITLE
(maint) Fix release for final versions

### DIFF
--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -459,7 +459,7 @@ Additional uberjar dependencies:
     (format "%s.%s"
             (str/replace lein-version #".*-" "0.1")
             (get-timestamp-string))
-    lein-version))
+    "1"))
 
 ;; TODO: this is a horrible, horrible hack; I can't yet see a good way to
 ;; let the packaging library know what the version number is without faking


### PR DESCRIPTION
The method to determine the release number was correctly setting the
release for SNAPSHOT builds but was errantly setting it to the version
if this was not a SNAPSHOT build. This fixes that method to return 1 for
non-SNAPSHOT builds, since we don't support custom release numbers.