### PR TITLE
(maint) Update EZBake to pull from the 1.0.x branch of packaging

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -1,5 +1,5 @@
 ---
-packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=1.0.x'
 packaging_repo: 'packaging'
 default_cow: 'base-jessie-i386.cow'
 cows: 'base-jessie-i386.cow base-xenial-i386.cow base-stretch-i386.cow'

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
@@ -1,5 +1,5 @@
 ---
-packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=1.0.x'
 packaging_repo: 'packaging'
 default_cow: 'base-trusty-amd64.cow'
 cows: 'base-trusty-amd64.cow base-xenial-amd64.cow'


### PR DESCRIPTION
This will enable us to utilize new and improved utilities that are
available in this branch.