### PR TITLE
(maint) We accidentally released 1.7.0 as 1.6.4.  Let's fix this up good.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,3 @@
-## 1.7.0 - 2017-11-08
-This is a feature and maintenance release.
-
-Feature:
-  * (EZ-111) Add support for RPM triggers. You can now add postinstall triggers
-    that run on either installs or upgrades via the
-    `redhat-postinst-install-triggers` or `redhat-postinst-upgrade-triggers`
-    variables under `:lein-ezbake` in your project.clj. These variables are
-    arrays of hashes in the format [ { :package "package", :scripts ["script 1", "script2"] } ]
-  * (EZ-113) Add support for Debian triggers. This adds support for activate
-    triggers via the `debian-activated-triggers` variable. This variable takes
-    an array of trigger names. This also adds support for interest triggers for
-    either install or upgrade via the `debian-interested-install-triggers` and
-    `debian-interested-upgrade-triggers` variables. These variables are arrays 
-    of hashes in the format [ { :interest-name "trigger", :scripts ["script1", "script2"] } ]
-    All of these variables are set under `:lein-ezbake` in your project.clj.
-
-Maintenance:
-  * Update the build_defaults to use the 1.0.x branch of the packaging repo 
-    (github.com/puppetlabs/packaging) to add support for the new puppet5 repos.
-
 ## 1.6.3 - 2017-10-02
 This is a bugfix release.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/lein-ezbake "1.7.0-SNAPSHOT"
+(defproject puppetlabs/lein-ezbake "1.6.4"
   :description "A system for building packages for trapperkeeper-based applications"
   :url "https://github.com/puppetlabs/ezbake"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/lein-ezbake "1.6.4"
+(defproject puppetlabs/lein-ezbake "1.6.5-SNAPSHOT"
   :description "A system for building packages for trapperkeeper-based applications"
   :url "https://github.com/puppetlabs/ezbake"
   :license {:name "Apache License 2.0"

--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -35,17 +35,6 @@ module EZBake
                           :additional_install => [{{{debian-install}}}],
                           :pre_start_action => [{{{debian-pre-start-action}}}],
                           :post_start_action => [{{{debian-post-start-action}}}],
-                          :interested_install_triggers => {
-                                                 {{#debian-interested-install-triggers}}
-                                                   "{{{interest-name}}}" => [{{{scripts}}}],
-                                                 {{/debian-interested-install-triggers}}
-                                                 },
-                          :interested_upgrade_triggers => {
-                                                 {{#debian-interested-upgrade-triggers}}
-                                                   "{{{interest-name}}}" => [{{{scripts}}}],
-                                                 {{/debian-interested-upgrade-triggers}}
-                                                 },
-                          :activated_triggers => [{{{debian-activated-triggers}}}],
                           },
       :redhat         => {
                           :additional_dependencies => [{{{redhat-deps}}}],

--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -44,16 +44,6 @@ module EZBake
                           :additional_install => [{{{redhat-install}}}],
                           :pre_start_action => [{{{redhat-pre-start-action}}}],
                           :post_start_action => [{{{redhat-post-start-action}}}],
-                          :postinst_install_triggers => {
-                                                 {{#redhat-postinst-install-triggers}}
-                                                   "{{{package}}}" => [{{{scripts}}}],
-                                                 {{/redhat-postinst-install-triggers}}
-                                                },
-                          :postinst_upgrade_triggers => {
-                                                 {{#redhat-postinst-upgrade-triggers}}
-                                                   "{{{package}}}" => [{{{scripts}}}],
-                                                 {{/redhat-postinst-upgrade-triggers}}
-                                                },
                           },
       :main_namespace => '{{{main-namespace}}}',
       :java_args      => '{{{java-args}}}',

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -1,5 +1,5 @@
 ---
-packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=1.0.x'
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 default_cow: 'base-jessie-i386.cow'
 cows: 'base-jessie-i386.cow base-xenial-i386.cow base-stretch-i386.cow'

--- a/resources/puppetlabs/lein-ezbake/template/global/controller.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/controller.sh.erb
@@ -161,15 +161,6 @@ else
                 params+=("--additional-dependency")
                 params+=("<%= dep -%>")
         <% end -%>
-        <%EZBake::Config[:debian][:interested_install_triggers].each do |interest_name, _| -%>
-                params+=("--deb-interest-trigger" "<%=interest_name-%>")
-        <% end -%>
-        <%EZBake::Config[:debian][:interested_upgrade_triggers].each do |interest_name, _| -%>
-                params+=("--deb-interest-trigger" "<%=interest_name-%>")
-        <% end -%>
-        <%EZBake::Config[:debian][:activated_triggers].each do |activated_name| -%>
-                params+=("--deb-activate-trigger" "<%=activated_name-%>")
-        <% end -%>
         : # Need something in case there are no additional dependencies
 fi
 

--- a/resources/puppetlabs/lein-ezbake/template/global/controller.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/controller.sh.erb
@@ -35,8 +35,6 @@ if [ ! -d "$basepath/old_sles" ]; then
         DESTDIR="$basepath/old_sles" bash install.sh sysv_init_suse
 fi
 
-<%- rpm_paths = [ "$basepath/systemd_el", "$basepath/old_el", "$basepath/old_sles" ] -%>
-
 # things are only different if we have docs, deb docs get
 # installed in an unversioned folder but rpm docs get installed
 # in a versioned folder.
@@ -129,30 +127,6 @@ if [[ "$os" = 'el' || "$os" = 'sles' || "$os" = 'fedora' ]]; then
         <%EZBake::Config[:redhat][:additional_dependencies].each do |dep| -%>
                 params+=("--additional-dependency")
                 params+=("<%= dep -%>")
-        <% end -%>
-        # get rpm install trigger scripts
-        <% EZBake::Config[:redhat][:postinst_install_triggers].each do |package, scripts|
-             rpm_paths.each do |path| -%>
-              cat > <%=path %>/<%=package%>_postinst_triggers <<EOM
-              if [ "\$1" -eq 1 ] ; then
-                 "<%= scripts.join("\n") %>"
-                 :
-              fi
-EOM
-            <% end -%>
-            params+=("--rpm-trigger" "'<%=package%>: $dir/<%=package%>_postinst_triggers'")
-        <% end -%>
-        # get rpm upgrade trigger scripts
-        <% EZBake::Config[:redhat][:postinst_upgrade_triggers].each do |package, scripts|
-             rpm_paths.each do |path| -%>
-             cat > <%=path %>/<%=package%>_postinst_triggers <<EOM
-              if [ "\$1" -gt 1 ] ; then
-                 "<%= scripts.join("\n") %>"
-                 :
-              fi
-EOM
-               <% end -%>
-            params+=("--rpm-trigger" "'<%=package%>: $dir/<%=package%>_postinst_triggers'")
         <% end -%>
         : # Need something in case there are no additional dependencies
 else

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/postinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/postinst.erb
@@ -13,19 +13,3 @@ if [ $1 = 'configure' -a -n $2 ] ; then
     invoke-rc.d <%= EZBake::Config[:project] %> try-restart || :
   fi
 fi
-
-# Run trigger scripts on install if defined
-if [ $1 = triggered ] && [ -z $2 ]; then
-  <% EZBake::Config[:debian][:interested_install_triggers].each do |_, scripts| -%>
-    <%= scripts.join("\n") %>
-  <% end -%>
-  : # in case there are no install triggers
-fi
-
-# Run trigger scripts on upgrade if defined
-if [ $1 = triggered ] && [ -n $2 ]; then
-  <% EZBake::Config[:debian][:interested_upgrade_triggers].each do |_, scripts| -%>
-    <%= scripts.join("\n") %>
-  <% end -%>
-  : # in case there are no upgrade triggers
-fi

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -29,8 +29,6 @@ options.termini = false
 options.termini_chdir = 'termini'
 options.termini_sources = ['opt']
 options.rpm_triggers = []
-options.deb_interest_triggers = []
-options.deb_activate_triggers = []
 
 OptionParser.new do |opts|
   opts.on('-o', '--operating-system OS', [:fedora, :el, :sles, :debian, :ubuntu], 'Select operating system (fedora, el, sles, debian, ubuntu)') do |o|
@@ -95,12 +93,6 @@ OptionParser.new do |opts|
   end
   opts.on('--rpm-trigger TRIGGER', 'TRIGGER for the rpm packages, in the format package:file_containing_script') do |t|
     options.rpm_triggers << t
-  end
-  opts.on('--deb-interest-trigger TRIGGER', 'name of the interest TRIGGER for the deb packages ') do |t|
-    options.deb_interest_triggers << t
-  end
-  opts.on('--deb-activate-trigger TRIGGER', 'name of the activate TRIGGER for the deb packages') do |t|
-    options.deb_activate_triggers << t
   end
   opts.on_tail("-h", "--help", "Show this message") do
     puts opts
@@ -216,14 +208,6 @@ if options.output_type == 'rpm'
 
   options.rpm_triggers.each do |trigger|
     fpm_opts << "--rpm-trigger-after-install #{trigger}"
-  end
-
-  options.deb_interest_triggers.each do |trigger|
-    fpm_opts << "--deb-interest #{trigger}"
-  end
-
-   options.deb_activate_triggers.each do |trigger|
-    fpm_opts << "--deb-activate #{trigger}"
   end
 
   if options.logrotate

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -28,7 +28,6 @@ options.logrotate = false
 options.termini = false
 options.termini_chdir = 'termini'
 options.termini_sources = ['opt']
-options.rpm_triggers = []
 
 OptionParser.new do |opts|
   opts.on('-o', '--operating-system OS', [:fedora, :el, :sles, :debian, :ubuntu], 'Select operating system (fedora, el, sles, debian, ubuntu)') do |o|
@@ -90,9 +89,6 @@ OptionParser.new do |opts|
   end
   opts.on('--termini-sources <SOURCES>', Array, 'sources for the termini build, defaults to "opt"') do |c|
     options.termini_chdir = c
-  end
-  opts.on('--rpm-trigger TRIGGER', 'TRIGGER for the rpm packages, in the format package:file_containing_script') do |t|
-    options.rpm_triggers << t
   end
   opts.on_tail("-h", "--help", "Show this message") do
     puts opts
@@ -204,10 +200,6 @@ if options.output_type == 'rpm'
 
   options.additional_dirs.each do |dir|
     fpm_opts << "--directories #{dir}"
-  end
-
-  options.rpm_triggers.each do |trigger|
-    fpm_opts << "--rpm-trigger-after-install #{trigger}"
   end
 
   if options.logrotate

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
@@ -1,5 +1,5 @@
 ---
-packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=1.0.x'
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 default_cow: 'base-trusty-amd64.cow'
 cows: 'base-trusty-amd64.cow base-xenial-amd64.cow'

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -55,10 +55,6 @@
   [{:package schema/Str
     :version schema/Str}])
 
-(def RPMTriggers
-  [{:package schema/Str
-    :scripts [schema/Str]}])
-
 (def LocalProjectVars
   {(schema/optional-key :user) schema/Str
    (schema/optional-key :group) schema/Str
@@ -75,8 +71,6 @@
    (schema/optional-key :open-file-limit) schema/Int
    (schema/optional-key :main-namespace) schema/Str
    (schema/optional-key :java-args) schema/Str
-   (schema/optional-key :redhat-postinst-install-triggers) RPMTriggers
-   (schema/optional-key :redhat-postinst-upgrade-triggers) RPMTriggers
    (schema/optional-key :logrotate-enabled) schema/Bool})
 
 (def UberjarInfo
@@ -486,11 +480,6 @@ Additional uberjar dependencies:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; File templates
 
-;; create rpm trigger hash
-(defn extract-rpm-package-scripts
-  [{:keys [package scripts]}]
-  {:package package :scripts (quoted-list scripts)})
-
 (defn make-template-map
   "Construct the map of variables to pass on to the ezbake.rb template"
   [lein-project build-target config-files system-config-files cli-app-files bin-files terminus-files upstream-ezbake-configs additional-uberjars]
@@ -499,65 +488,63 @@ Additional uberjar dependencies:
                    :version version
                    :files (quoted-list files)})
         get-quoted-ezbake-values (fn [platform variable]
-                                        (quoted-list
-                                        (get-ezbake-value (get-ezbake-vars lein-project)
+                                   (quoted-list
+                                    (get-ezbake-value (get-ezbake-vars lein-project)
                                                       upstream-ezbake-configs
                                                       build-target
                                                       platform
                                                       variable)))]
-    {:project                           (:name lein-project)
-     :packaging-version                 (generate-package-version-from-version (:version lein-project))
-     :packaging-release                 (generate-package-release-from-version (:version lein-project))
-     :real-name                         (get-real-name (:name lein-project))
-     :user                              (get-local-ezbake-var lein-project :user
+    {:project                   (:name lein-project)
+     :packaging-version         (generate-package-version-from-version (:version lein-project))
+     :packaging-release         (generate-package-release-from-version (:version lein-project))
+     :real-name                 (get-real-name (:name lein-project))
+     :user                      (get-local-ezbake-var lein-project :user
                                                       (:name lein-project))
-     :group                             (get-local-ezbake-var lein-project :group
+     :group                     (get-local-ezbake-var lein-project :group
                                                       (:name lein-project))
-     :uberjar-name                      (:uberjar-name lein-project)
-     :config-files                      (quoted-list (map remove-erb-extension config-files))
-     :system-config-files               (quoted-list (map remove-erb-extension system-config-files))
-     :cli-app-files                     (quoted-list (map remove-erb-extension cli-app-files))
-     :cli-defaults-file                 (remove-erb-extension cli-defaults-filename)
-     :bin-files                         (quoted-list bin-files)
-     :create-dirs                       (quoted-list (get-local-ezbake-var lein-project
+     :uberjar-name              (:uberjar-name lein-project)
+     :config-files              (quoted-list (map remove-erb-extension config-files))
+     :system-config-files       (quoted-list (map remove-erb-extension system-config-files))
+     :cli-app-files             (quoted-list (map remove-erb-extension cli-app-files))
+     :cli-defaults-file         (remove-erb-extension cli-defaults-filename)
+     :bin-files                 (quoted-list bin-files)
+     :create-dirs               (quoted-list (get-local-ezbake-var lein-project
                                                                    :create-dirs []))
-     :debian-deps                       (get-quoted-ezbake-values :debian :dependencies)
-     :debian-build-deps                 (get-quoted-ezbake-values :debian :build-dependencies)
-     :debian-preinst                    (get-quoted-ezbake-values :debian :preinst)
-     :debian-prerm                      (get-quoted-ezbake-values :debian :prerm)
-     :debian-postinst                   (get-quoted-ezbake-values :debian :postinst)
-     :debian-install                    (get-quoted-ezbake-values :debian :install)
-     :debian-pre-start-action           (get-quoted-ezbake-values :debian :pre-start-action)
-     :debian-post-start-action          (get-quoted-ezbake-values :debian :post-start-action)
-     :redhat-deps                       (get-quoted-ezbake-values :redhat :dependencies)
-     :redhat-build-deps                 (get-quoted-ezbake-values :redhat :build-dependencies)
-     :redhat-preinst                    (get-quoted-ezbake-values :redhat :preinst)
-     :redhat-postinst                   (get-quoted-ezbake-values :redhat :postinst)
-     :redhat-install                    (get-quoted-ezbake-values :redhat :install)
-     :redhat-pre-start-action           (get-quoted-ezbake-values :redhat :pre-start-action)
-     :redhat-post-start-action          (get-quoted-ezbake-values :redhat :post-start-action)
-     :terminus-map                      termini
-     :replaces-pkgs                     (get-local-ezbake-var lein-project :replaces-pkgs [])
-     :redhat-postinst-install-triggers  (map extract-rpm-package-scripts (get-local-ezbake-var lein-project :redhat-postinst-install-triggers []))
-     :redhat-postinst-upgrade-triggers  (map extract-rpm-package-scripts (get-local-ezbake-var lein-project :redhat-postinst-upgrade-triggers []))
-     :start-after                       (quoted-list (get-local-ezbake-var lein-project :start-after []))
-     :reload-timeout                    (get-local-ezbake-var lein-project :reload-timeout "120")
-     :start-timeout                     (get-local-ezbake-var lein-project :start-timeout "300")
-     :stop-timeout                      (get-local-ezbake-var lein-project :stop-timeout "60")
-     :open-file-limit                   (get-local-ezbake-var lein-project :open-file-limit "nil")
-     :is-pe-build                       (format "%s" (= (get-local-ezbake-var lein-project :build-type "foss") "pe"))
-     :main-namespace                    (get-local-ezbake-var lein-project
+     :debian-deps               (get-quoted-ezbake-values :debian :dependencies)
+     :debian-build-deps         (get-quoted-ezbake-values :debian :build-dependencies)
+     :debian-preinst            (get-quoted-ezbake-values :debian :preinst)
+     :debian-prerm              (get-quoted-ezbake-values :debian :prerm)
+     :debian-postinst           (get-quoted-ezbake-values :debian :postinst)
+     :debian-install            (get-quoted-ezbake-values :debian :install)
+     :debian-pre-start-action   (get-quoted-ezbake-values :debian :pre-start-action)
+     :debian-post-start-action  (get-quoted-ezbake-values :debian :post-start-action)
+     :redhat-deps               (get-quoted-ezbake-values :redhat :dependencies)
+     :redhat-build-deps         (get-quoted-ezbake-values :redhat :build-dependencies)
+     :redhat-preinst            (get-quoted-ezbake-values :redhat :preinst)
+     :redhat-postinst           (get-quoted-ezbake-values :redhat :postinst)
+     :redhat-install            (get-quoted-ezbake-values :redhat :install)
+     :redhat-pre-start-action   (get-quoted-ezbake-values :redhat :pre-start-action)
+     :redhat-post-start-action  (get-quoted-ezbake-values :redhat :post-start-action)
+     :terminus-map              termini
+     :replaces-pkgs             (get-local-ezbake-var lein-project :replaces-pkgs [])
+     :start-after               (quoted-list (get-local-ezbake-var lein-project :start-after []))
+     :reload-timeout            (get-local-ezbake-var lein-project :reload-timeout "120")
+     :start-timeout             (get-local-ezbake-var lein-project :start-timeout "300")
+     :stop-timeout              (get-local-ezbake-var lein-project :stop-timeout "60")
+     :open-file-limit           (get-local-ezbake-var lein-project :open-file-limit "nil")
+     :is-pe-build               (format "%s" (= (get-local-ezbake-var lein-project :build-type "foss") "pe"))
+     :main-namespace            (get-local-ezbake-var lein-project
                                                       :main-namespace
                                                       "puppetlabs.trapperkeeper.main")
-     :java-args                         (get-local-ezbake-var lein-project :java-args
+     :java-args                 (get-local-ezbake-var lein-project :java-args
                                                       "-Xmx192m")
      ; Convert to string so ruby doesn't barf on the hyphens
-     :bootstrap-source                  (name (get-local-ezbake-var lein-project
+     :bootstrap-source          (name (get-local-ezbake-var lein-project
                                                             :bootstrap-source
                                                             :bootstrap-cfg))
-     :logrotate-enabled                 (get-local-ezbake-var lein-project :logrotate-enabled
+     :logrotate-enabled         (get-local-ezbake-var lein-project :logrotate-enabled
                                                       true)
-     :additional-uberjars               (quoted-list additional-uberjars)}))
+     :additional-uberjars       (quoted-list additional-uberjars)}))
 
 ;; TODO: this is wonky; we're basically doing some templating here and it
 ;; might make more sense to use an actual template for it.  However, I'm a bit

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -59,10 +59,6 @@
   [{:package schema/Str
     :scripts [schema/Str]}])
 
-(def DEBTriggers
-  [{:interest-name schema/Str
-    :scripts [schema/Str]}])
-
 (def LocalProjectVars
   {(schema/optional-key :user) schema/Str
    (schema/optional-key :group) schema/Str
@@ -81,9 +77,6 @@
    (schema/optional-key :java-args) schema/Str
    (schema/optional-key :redhat-postinst-install-triggers) RPMTriggers
    (schema/optional-key :redhat-postinst-upgrade-triggers) RPMTriggers
-   (schema/optional-key :debian-interested-install-triggers) DEBTriggers
-   (schema/optional-key :debian-interested-upgrade-triggers) DEBTriggers
-   (schema/optional-key :debian-activated-triggers) [schema/Str]
    (schema/optional-key :logrotate-enabled) schema/Bool})
 
 (def UberjarInfo
@@ -498,11 +491,6 @@ Additional uberjar dependencies:
   [{:keys [package scripts]}]
   {:package package :scripts (quoted-list scripts)})
 
-;; create debian trigger hash
-(defn extract-deb-package-scripts
-  [{:keys [interest-name scripts]}]
-  {:interest-name interest-name :scripts (quoted-list scripts)})
-
 (defn make-template-map
   "Construct the map of variables to pass on to the ezbake.rb template"
   [lein-project build-target config-files system-config-files cli-app-files bin-files terminus-files upstream-ezbake-configs additional-uberjars]
@@ -511,68 +499,65 @@ Additional uberjar dependencies:
                    :version version
                    :files (quoted-list files)})
         get-quoted-ezbake-values (fn [platform variable]
-                                         (quoted-list
-                                         (get-ezbake-value (get-ezbake-vars lein-project)
+                                        (quoted-list
+                                        (get-ezbake-value (get-ezbake-vars lein-project)
                                                       upstream-ezbake-configs
                                                       build-target
                                                       platform
                                                       variable)))]
-    {:project                            (:name lein-project)
-     :packaging-version                  (generate-package-version-from-version (:version lein-project))
-     :packaging-release                  (generate-package-release-from-version (:version lein-project))
-     :real-name                          (get-real-name (:name lein-project))
-     :user                               (get-local-ezbake-var lein-project :user
+    {:project                           (:name lein-project)
+     :packaging-version                 (generate-package-version-from-version (:version lein-project))
+     :packaging-release                 (generate-package-release-from-version (:version lein-project))
+     :real-name                         (get-real-name (:name lein-project))
+     :user                              (get-local-ezbake-var lein-project :user
                                                       (:name lein-project))
-     :group                              (get-local-ezbake-var lein-project :group
+     :group                             (get-local-ezbake-var lein-project :group
                                                       (:name lein-project))
-     :uberjar-name                       (:uberjar-name lein-project)
-     :config-files                       (quoted-list (map remove-erb-extension config-files))
-     :system-config-files                (quoted-list (map remove-erb-extension system-config-files))
-     :cli-app-files                      (quoted-list (map remove-erb-extension cli-app-files))
-     :cli-defaults-file                  (remove-erb-extension cli-defaults-filename)
-     :bin-files                          (quoted-list bin-files)
-     :create-dirs                        (quoted-list (get-local-ezbake-var lein-project
+     :uberjar-name                      (:uberjar-name lein-project)
+     :config-files                      (quoted-list (map remove-erb-extension config-files))
+     :system-config-files               (quoted-list (map remove-erb-extension system-config-files))
+     :cli-app-files                     (quoted-list (map remove-erb-extension cli-app-files))
+     :cli-defaults-file                 (remove-erb-extension cli-defaults-filename)
+     :bin-files                         (quoted-list bin-files)
+     :create-dirs                       (quoted-list (get-local-ezbake-var lein-project
                                                                    :create-dirs []))
-     :debian-deps                        (get-quoted-ezbake-values :debian :dependencies)
-     :debian-build-deps                  (get-quoted-ezbake-values :debian :build-dependencies)
-     :debian-preinst                     (get-quoted-ezbake-values :debian :preinst)
-     :debian-prerm                       (get-quoted-ezbake-values :debian :prerm)
-     :debian-postinst                    (get-quoted-ezbake-values :debian :postinst)
-     :debian-install                     (get-quoted-ezbake-values :debian :install)
-     :debian-pre-start-action            (get-quoted-ezbake-values :debian :pre-start-action)
-     :debian-post-start-action           (get-quoted-ezbake-values :debian :post-start-action)
-     :debian-activated-triggers          (quoted-list (get-local-ezbake-var lein-project :debian-activated-triggers []))
-     :debian-interested-install-triggers (map  extract-deb-package-scripts (get-local-ezbake-var lein-project :debian-interested-install-triggers []))
-     :debian-interested-upgrade-triggers (map  extract-deb-package-scripts (get-local-ezbake-var lein-project :debian-interested-upgrade-triggers []))
-     :redhat-deps                        (get-quoted-ezbake-values :redhat :dependencies)
-     :redhat-build-deps                  (get-quoted-ezbake-values :redhat :build-dependencies)
-     :redhat-preinst                     (get-quoted-ezbake-values :redhat :preinst)
-     :redhat-postinst                    (get-quoted-ezbake-values :redhat :postinst)
-     :redhat-install                     (get-quoted-ezbake-values :redhat :install)
-     :redhat-pre-start-action            (get-quoted-ezbake-values :redhat :pre-start-action)
-     :redhat-post-start-action           (get-quoted-ezbake-values :redhat :post-start-action)
-     :terminus-map                       termini
-     :replaces-pkgs                      (get-local-ezbake-var lein-project :replaces-pkgs [])
-     :redhat-postinst-install-triggers   (map extract-rpm-package-scripts (get-local-ezbake-var lein-project :redhat-postinst-install-triggers []))
-     :redhat-postinst-upgrade-triggers   (map extract-rpm-package-scripts (get-local-ezbake-var lein-project :redhat-postinst-upgrade-triggers []))
-     :start-after                        (quoted-list (get-local-ezbake-var lein-project :start-after []))
-     :reload-timeout                     (get-local-ezbake-var lein-project :reload-timeout "120")
-     :start-timeout                      (get-local-ezbake-var lein-project :start-timeout "300")
-     :stop-timeout                       (get-local-ezbake-var lein-project :stop-timeout "60")
-     :open-file-limit                    (get-local-ezbake-var lein-project :open-file-limit "nil")
-     :is-pe-build                        (format "%s" (= (get-local-ezbake-var lein-project :build-type "foss") "pe"))
-     :main-namespace                     (get-local-ezbake-var lein-project
+     :debian-deps                       (get-quoted-ezbake-values :debian :dependencies)
+     :debian-build-deps                 (get-quoted-ezbake-values :debian :build-dependencies)
+     :debian-preinst                    (get-quoted-ezbake-values :debian :preinst)
+     :debian-prerm                      (get-quoted-ezbake-values :debian :prerm)
+     :debian-postinst                   (get-quoted-ezbake-values :debian :postinst)
+     :debian-install                    (get-quoted-ezbake-values :debian :install)
+     :debian-pre-start-action           (get-quoted-ezbake-values :debian :pre-start-action)
+     :debian-post-start-action          (get-quoted-ezbake-values :debian :post-start-action)
+     :redhat-deps                       (get-quoted-ezbake-values :redhat :dependencies)
+     :redhat-build-deps                 (get-quoted-ezbake-values :redhat :build-dependencies)
+     :redhat-preinst                    (get-quoted-ezbake-values :redhat :preinst)
+     :redhat-postinst                   (get-quoted-ezbake-values :redhat :postinst)
+     :redhat-install                    (get-quoted-ezbake-values :redhat :install)
+     :redhat-pre-start-action           (get-quoted-ezbake-values :redhat :pre-start-action)
+     :redhat-post-start-action          (get-quoted-ezbake-values :redhat :post-start-action)
+     :terminus-map                      termini
+     :replaces-pkgs                     (get-local-ezbake-var lein-project :replaces-pkgs [])
+     :redhat-postinst-install-triggers  (map extract-rpm-package-scripts (get-local-ezbake-var lein-project :redhat-postinst-install-triggers []))
+     :redhat-postinst-upgrade-triggers  (map extract-rpm-package-scripts (get-local-ezbake-var lein-project :redhat-postinst-upgrade-triggers []))
+     :start-after                       (quoted-list (get-local-ezbake-var lein-project :start-after []))
+     :reload-timeout                    (get-local-ezbake-var lein-project :reload-timeout "120")
+     :start-timeout                     (get-local-ezbake-var lein-project :start-timeout "300")
+     :stop-timeout                      (get-local-ezbake-var lein-project :stop-timeout "60")
+     :open-file-limit                   (get-local-ezbake-var lein-project :open-file-limit "nil")
+     :is-pe-build                       (format "%s" (= (get-local-ezbake-var lein-project :build-type "foss") "pe"))
+     :main-namespace                    (get-local-ezbake-var lein-project
                                                       :main-namespace
                                                       "puppetlabs.trapperkeeper.main")
-     :java-args                          (get-local-ezbake-var lein-project :java-args
+     :java-args                         (get-local-ezbake-var lein-project :java-args
                                                       "-Xmx192m")
      ; Convert to string so ruby doesn't barf on the hyphens
-     :bootstrap-source                   (name (get-local-ezbake-var lein-project
+     :bootstrap-source                  (name (get-local-ezbake-var lein-project
                                                             :bootstrap-source
                                                             :bootstrap-cfg))
-     :logrotate-enabled                  (get-local-ezbake-var lein-project :logrotate-enabled
+     :logrotate-enabled                 (get-local-ezbake-var lein-project :logrotate-enabled
                                                       true)
-     :additional-uberjars                (quoted-list additional-uberjars)}))
+     :additional-uberjars               (quoted-list additional-uberjars)}))
 
 ;; TODO: this is wonky; we're basically doing some templating here and it
 ;; might make more sense to use an actual template for it.  However, I'm a bit


### PR DESCRIPTION
Especially since I found a bug that's going to require a 1.6.5, let's revert all the 1.7.0 stuff until that gets in, then rebuild 1.7.0 with the triggers stuff.