### PR TITLE
(maint) Missed a couple of pass-throughs to fpm

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/controller.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/controller.sh.erb
@@ -122,6 +122,10 @@ params+=('--logrotate')
 params+=('--replaces' "<%= package -%>,<%= version -%>")
 <% end %>
 
+<% EZBake::Config[:create_dirs].each do |directory| -%>
+params+=('--create-dir' '<%= directory -%>')
+<% end %>
+
 <% if EZBake::Config[:is_pe_build] -%>
 params+=('--enterprise-build')
 <% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/global/controller.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/controller.sh.erb
@@ -118,6 +118,10 @@ fi
 params+=('--logrotate')
 <% end -%>
 
+<% EZBake::Config[:replaces_pkgs].each do |package, version| -%>
+params+=('--replaces' "<%= package -%>,<%= version -%>")
+<% end %>
+
 <% if EZBake::Config[:is_pe_build] -%>
 params+=('--enterprise-build')
 <% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -200,6 +200,7 @@ if options.output_type == 'rpm'
 
   options.additional_dirs.each do |dir|
     fpm_opts << "--directories #{dir}"
+    fpm_opts << "--rpm-attr 700,#{options.user},#{options.group}:#{dir}"
   end
 
   if options.logrotate


### PR DESCRIPTION
When converting the existing packaging files to fpm, I missed the pass-throughs for `replaces_pkgs` and `create_dirs`.