### PR TITLE
(SERVER-2068) Be more discerning finding PIDs

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/reload.erb
@@ -17,7 +17,7 @@ fi
 init_restart_file "$restartfile" || exit $?
 
 initial="$(head -n 1 "$restartfile")"
-pid="$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)"
+pid="$(pgrep -f "<%= EZBake::Config[:uberjar_name] %>.* -m <%= EZBake::Config[:main_namespace] %>")"
 kill -HUP $pid >/dev/null 2>&1
 if [ $? -ne 0 ]; then
     echo "Service not running so cannot be reloaded" 1>&2

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set +e
 
-pid="$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)"
+pid="$(pgrep -f "<%= EZBake::Config[:uberjar_name] %>.* -m <%= EZBake::Config[:main_namespace] %>")"
 
 restartfile="/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/restartcounter"
 start_timeout="${START_TIMEOUT:-<%= EZBake::Config[:start_timeout] %>}"

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/stop.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/stop.erb
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set +e
 
-pid="$(pgrep -f <%= EZBake::Config[:uberjar_name] %>)"
+pid="$(pgrep -f "<%= EZBake::Config[:uberjar_name] %>.* -m <%= EZBake::Config[:main_namespace] %>")"
 realname="<%= EZBake::Config[:real_name] %>"
 PIDFILE="/var/run/puppetlabs/${realname}/${realname}.pid"
 


### PR DESCRIPTION
Previously, the start/stop/reload scripts would use a `pgrep` to search
for running processes, to determine if the service was still running.
That `pgrep` would do a simple search for uberjar name.

Turns out, that's not specific enough. In the case of puppetserver, a
user invocation of `puppetserver gem list` will put a process in the
process list that the naive `pgrep` would finger as the service pid in
the event puppetserver wasn't actually running. This could trick a
service manager into thinking puppetserver was running when in fact it
could be stopped for hours.

This commit doesn't change the basic service detection logic, but it
improves the `pgrep` to be more discerning, and search not only for the
uberjar name but also for the main namespace.