### PR TITLE
(EZ-112) Don't start puppetserver until networking comes online

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
@@ -10,7 +10,7 @@
 #
 [Unit]
 Description=<%= EZBake::Config[:project] %> Service
-After=syslog.target network.target
+After=syslog.target network.target network-online.target
 
 [Service]
 Type=forking

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
@@ -10,7 +10,7 @@
 #
 [Unit]
 Description=<%= EZBake::Config[:project] %> Service
-After=syslog.target network.target <%= EZBake::Config[:start_after].map {|dep| "#{dep}.service" }.join(" ") %>
+After=syslog.target network.target network-online.target <%= EZBake::Config[:start_after].map {|dep| "#{dep}.service" }.join(" ") %>
 
 [Service]
 Type=forking


### PR DESCRIPTION
pe-puppetserver has a dependency on the network.target, which ensures that the network is started prior to starting the pe-puppetserver. However, the pe-puppetserver really needs the network to be online prior to starting if it has to do any DNS lookups. Since the service can start prior to the network coming online, it can cause nscd to cache a negative response to DNS lookups and delay the startup of the service.