### PR TITLE
(EZ-20) EZBake defaults templates should create a separate variable f…

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/cli-app.erb
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/cli-app.erb
@@ -11,6 +11,7 @@ elif [ -r "/etc/sysconfig/<%= EZBake::Config[:project] -%>" ] ; then
 elif [ `uname` == "OpenBSD" ] ; then
     JAVA_BIN=$(javaPathHelper -c <%= EZBake::Config[:project] %>)
     JAVA_ARGS="<%= EZBake::Config[:java_args] %>"
+    TK_ARGS="<%= EZBake::Config[:tk_args] %>"
     USER="_<%= EZBake::Config[:user] %>"
     INSTALL_DIR="/opt/puppetlabs/server/apps/<%= EZBake::Config[:project] %>"
     CONFIG="/etc/puppetlabs/<%= EZBake::Config[:project] %>/conf.d"

--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -70,6 +70,7 @@ module EZBake
                           },
       :main_namespace => '{{{main-namespace}}}',
       :java_args      => '{{{java-args}}}',
+      :tk_args        => '{{{tk-args}}}',
       :start_after    => [{{{start-after}}}],
       :replaces_pkgs  => {
                           {{#replaces-pkgs}}

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
@@ -8,6 +8,9 @@ JAVA_BIN="/usr/bin/java"
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
 JAVA_ARGS="<%= EZBake::Config[:java_args] %>"
 
+# Modify this if you'd like TrapperKeeper specific arguments
+TK_ARGS="<%= EZBake::Config[:tk_args] %>"
+
 # These normally shouldn't need to be edited if using OS packages
 USER="<%= EZBake::Config[:user] %>"
 GROUP="<%= EZBake::Config[:group] %>"

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
@@ -33,6 +33,7 @@ COMMAND="${JAVA_BIN} ${JAVA_ARGS} ${LOG_APPENDER} \
          clojure.main -m <%= EZBake::Config[:main_namespace] %> \
          --config ${CONFIG} --bootstrap-config ${BOOTSTRAP_CONFIG} \
          --restart-file "${restartfile}" \
+         ${TK_ARGS} \
          ${@}"
 
 pushd "${INSTALL_DIR}" &> /dev/null

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -66,7 +66,8 @@ ${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=/dev/urandom \
   -m <%= EZBake::Config[:main_namespace] %> \
   --config "${CONFIG}" \
   --bootstrap-config "${BOOTSTRAP_CONFIG}" \
-  --restart-file "${restartfile}" &
+  --restart-file "${restartfile}" \
+  ${TK_ARGS} &
 
 # $! is the process id of the last backgrounded process, the Java process above.
 pid=$!

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/default.erb
@@ -8,6 +8,9 @@ JAVA_BIN="/opt/puppetlabs/server/bin/java"
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
 JAVA_ARGS="<%= EZBake::Config[:java_args] %>"
 
+# Modify this if you'd like TrapperKeeper specific arguments
+TK_ARGS="<%= EZBake::Config[:tk_args] %>"
+
 # These normally shouldn't need to be edited if using OS packages
 USER="<%= EZBake::Config[:user] %>"
 GROUP="<%= EZBake::Config[:group] %>"

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -79,6 +79,7 @@
    (schema/optional-key :open-file-limit) schema/Int
    (schema/optional-key :main-namespace) schema/Str
    (schema/optional-key :java-args) schema/Str
+   (schema/optional-key :tk-args) schema/Str
    (schema/optional-key :redhat-postinst-install-triggers) RPMTriggers
    (schema/optional-key :redhat-postinst-upgrade-triggers) RPMTriggers
    (schema/optional-key :debian-interested-install-triggers) DEBTriggers
@@ -568,6 +569,8 @@ Additional uberjar dependencies:
                                                       "puppetlabs.trapperkeeper.main")
      :java-args                          (get-local-ezbake-var lein-project :java-args
                                                       "-Xmx192m")
+     :tk-args                            (get-local-ezbake-var lein-project :tk-args
+                                                       "" )
      ; Convert to string so ruby doesn't barf on the hyphens
      :bootstrap-source                   (name (get-local-ezbake-var lein-project
                                                             :bootstrap-source


### PR DESCRIPTION
…or TrapperKeeper arguments

Adding TrapperKeeper-specific arguments to java_args, such as --debug, causes java to give up and exit.
This makes a separate variable, TK_ARGS, in the defaults file that could be used to adjust the flags passed to daemons and command line tools.