### PR TITLE
(maint) Add openjdk-10+ support

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/control.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/control.erb
@@ -25,7 +25,7 @@ end-%>
 <% if EZBake::Config[:is_pe_build] -%>
 Depends: ${misc:Depends}, pe-java, pe-puppet-enterprise-release, net-tools, adduser, procps<%= additional_dependencies_string -%>
 <% else -%>
-Depends: ${misc:Depends}, openjdk-8-jre-headless, net-tools, adduser, procps<%= additional_dependencies_string -%>
+Depends: ${misc:Depends}, openjdk-8-jre-headless | openjdk-11-jre-headless, net-tools, adduser, procps<%= additional_dependencies_string -%>
 <% end %>
 Replaces: <%= EZBake::Config[:replaces_pkgs].map {|package, version| "#{package} (<< #{version}-1#{Pkg::Config.packager}1)" }.join(",") %>
 Conflicts: <%= EZBake::Config[:replaces_pkgs].map {|package, version| "#{package} (<< #{version}-1#{Pkg::Config.packager}1)" }.join(",") %>


### PR DESCRIPTION
Ubuntu Bionic ships a 'openjdk-11' package set. Currently this contains openjdk 10 builds, but will move to 11 once it stabilizes. This adds it as an allowed dependency for Debian/Ubuntu builds.