### PR TITLE
(EZ-127) Add docker-build to build an image from a clojure repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,16 @@ by setting the `MOCK` environment variable and deb targets can be overwritten
 by setting the `COW` environment variable. These variables should be
 space-separated lists of rpm(MOCK) and deb(COW) platforms.
 
+#### `docker-build`
+
+```shell
+lein with-profile ezbake ezbake docker-build
+```
+
+This will build a container image using the settings in the `:docker` section
+of the `:lein-ezbake` config in `project.clj`. See [Building container images](#building-container-images)
+below for more detail.
+
 #### `legacy-build`
 
 ```shell
@@ -536,6 +546,33 @@ After building packages it is often necessary to install those packages in live
 environments on the OSes supported by the ezbake templates. For this purpose
 [Puppetlabs' Beaker](https://github.com/puppetlabs/beaker) is the, uh, choice
 tool of discerning developers.
+
+### Building container images
+
+EZBake can also be used to build docker images. The command `lein ezbake
+docker-build` can be used to build an image using config specified in
+`<config-dir>/docker`. The result will be an image derived from the
+`openjdk:8-jre-alpine` base image, with an entrypoint set to the correct java
+invocation to run the service. Config files will be located in `/config/conf.d`
+and the bootstrap file in `/config/bootstrap.cfg`. The project uberjar and any
+additional uberjars will be in `/src`.
+
+Some variables can be set under the `:docker` key in `project.clj`:
+
+```clojure
+{:lein-ezbake {
+  :config-dir "config"
+  :vars {
+    :docker {
+      ; Specify ports to be exposed in the container
+      :ports [8140]
+      ; Tag the image with a specific name. Defaults to the project name
+      :image-name "myproject"
+      ; Override the base image. Defaults to openjdk:8-jre-alpine
+      :base-image "openjdk:8-jre-alpine"}}}}
+```
+
+This feature is currently **experimental**.
 
 ## Maintainers
 

--- a/resources/puppetlabs/lein-ezbake/staging-templates/Dockerfile.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/Dockerfile.mustache
@@ -1,0 +1,12 @@
+FROM {{{base-image}}}
+
+COPY *.jar /src/
+COPY Dockerfile /Dockerfile
+COPY ext/config/docker /config
+
+VOLUME /ssl
+
+{{{expose-ports}}}
+
+ENTRYPOINT java -Djava.security.egd=/dev/urandom -XX:OnOutOfMemoryError="kill -9 %p" -cp "{{{classpath}}}" clojure.main -m puppetlabs.trapperkeeper.main --config /config/conf.d --bootstrap-config /config/bootstrap.cfg
+


### PR DESCRIPTION
This adds a new `lein ezbake docker-build` command which can be used to
generate a standardized docker image from a trapperkeeper project.

The resulting image has the requisite java invocation set as its
entrypoint, referring a bootstrap.cfg and conf.d both located at
/config, and setting the classpath set to the project uberjar and any
additional jars, which are placed into /src. The base image defaults to
openjdk:8-jre-alpine, but can be overridden in the project.clj. Ports
to be exposed can be included in project.clj, as well as the name to tag
the image with, which defaults to the project name.