### PR TITLE
(EZ-128) Add support for specifying numeric uid/gid in rpm packages

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -5,6 +5,7 @@ module EZBake
       :release        => '{{{packaging-release}}}',
       :real_name      => '{{{real-name}}}',
       :user           => '{{{user}}}',
+      :numeric_uid_gid => {{{numeric-uid-gid}}},
       :group          => '{{{group}}}',
       :reload_timeout => '{{{reload-timeout}}}',
       :start_timeout  => '{{{start-timeout}}}',

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/preinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/preinst.erb
@@ -2,12 +2,25 @@
 # install.sh source based installation methodology.
 #
 # Add <%= EZBake::Config[:group] %> group
-getent group <%= EZBake::Config[:group] %> > /dev/null || \
+if getent group <%= EZBake::Config[:group] %> > /dev/null; then
+  : noop
+<% unless EZBake::Config[:numeric_uid_gid].nil? -%>
+elif ! getent group <%= EZBake::Config[:numeric_uid_gid] %> > /dev/null; then
+  groupadd -r --gid <%= EZBake::Config[:numeric_uid_gid] %> <%= EZBake::Config[:group] %> || :
+<% end -%>
+else
   groupadd -r <%= EZBake::Config[:group] %> || :
+fi
+
 # Add <%= EZBake::Config[:user] %> user
 if getent passwd <%= EZBake::Config[:user] %> > /dev/null; then
   usermod --gid <%= EZBake::Config[:group] %> --home %{_app_data} \
   --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
+<% unless EZBake::Config[:numeric_uid_gid].nil? -%>
+  elif ! getent passwd <%= EZBake::Config[:numeric_uid_gid] %> > /dev/null; then
+  useradd -r --uid <%= EZBake::Config[:numeric_uid_gid] %> --gid <%= EZBake::Config[:group] %> --home %{_app_data} --shell $(which nologin) \
+    --comment "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :
+<% end %>
 else
   useradd -r --gid <%= EZBake::Config[:group] %> --home %{_app_data} --shell $(which nologin) \
     --comment "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/preinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/preinst.erb
@@ -2,25 +2,21 @@
 # install.sh source based installation methodology.
 #
 # Add <%= EZBake::Config[:group] %> group
-if getent group <%= EZBake::Config[:group] %> > /dev/null; then
-  : noop
-<% unless EZBake::Config[:numeric_uid_gid].nil? -%>
-elif ! getent group <%= EZBake::Config[:numeric_uid_gid] %> > /dev/null; then
-  groupadd -r --gid <%= EZBake::Config[:numeric_uid_gid] %> <%= EZBake::Config[:group] %> || :
+<% if EZBake::Config[:numeric_uid_gid].nil? -%>
+getent group <%= EZBake::Config[:group] %> >/dev/null || groupadd --system --force <%= EZBake::Config[:group] %>
+<% else -%>
+getent group <%= EZBake::Config[:group] %> >/dev/null || groupadd --system --force --gid <%= EZBake::Config[:numeric_uid_gid] %> <%= EZBake::Config[:group] %>
 <% end -%>
-else
-  groupadd -r <%= EZBake::Config[:group] %> || :
-fi
 
 # Add <%= EZBake::Config[:user] %> user
 if getent passwd <%= EZBake::Config[:user] %> > /dev/null; then
   usermod --gid <%= EZBake::Config[:group] %> --home %{_app_data} \
   --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
 <% unless EZBake::Config[:numeric_uid_gid].nil? -%>
-  elif ! getent passwd <%= EZBake::Config[:numeric_uid_gid] %> > /dev/null; then
+elif ! getent passwd <%= EZBake::Config[:numeric_uid_gid] %> > /dev/null; then
   useradd -r --uid <%= EZBake::Config[:numeric_uid_gid] %> --gid <%= EZBake::Config[:group] %> --home %{_app_data} --shell $(which nologin) \
     --comment "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :
-<% end %>
+<% end -%>
 else
   useradd -r --gid <%= EZBake::Config[:group] %> --home %{_app_data} --shell $(which nologin) \
     --comment "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/preinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/preinst.erb
@@ -12,14 +12,14 @@ getent group <%= EZBake::Config[:group] %> >/dev/null || groupadd --system --for
 if getent passwd <%= EZBake::Config[:user] %> > /dev/null; then
   usermod --gid <%= EZBake::Config[:group] %> --home %{_app_data} \
   --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
-<% unless EZBake::Config[:numeric_uid_gid].nil? -%>
-elif ! getent passwd <%= EZBake::Config[:numeric_uid_gid] %> > /dev/null; then
-  useradd -r --uid <%= EZBake::Config[:numeric_uid_gid] %> --gid <%= EZBake::Config[:group] %> --home %{_app_data} --shell $(which nologin) \
-    --comment "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :
-<% end -%>
 else
-  useradd -r --gid <%= EZBake::Config[:group] %> --home %{_app_data} --shell $(which nologin) \
-    --comment "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :
+  useradd_options=('--system' '--gid' '<%= EZBake::Config[:group] %>' '--home' '%{_app_data}' '--shell' "$(which nologin)" '--comment' '<%= EZBake::Config[:project] %> daemon')
+<% unless EZBake::Config[:numeric_uid_gid].nil? -%>
+  if ! getent passwd <%= EZBake::Config[:numeric_uid_gid] %> > /dev/null; then
+    useradd_options+=('--uid' '<%= EZBake::Config[:numeric_uid_gid] %>')
+  fi
+<% end -%>
+  useradd "${useradd_options[@]}" <%= EZBake::Config[:user] %> || :
 fi
 <% if defined?(additional_preinst)
 additional_preinst.split(',').each do |cmd| -%>

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -70,6 +70,7 @@
 
 (def LocalProjectVars
   {(schema/optional-key :user) schema/Str
+   (schema/optional-key :numeric-uid-gid) schema/Int
    (schema/optional-key :group) schema/Str
    (schema/optional-key :bootstrap-source) BootstrapSource
    (schema/optional-key :create-dirs) [schema/Str]
@@ -530,6 +531,7 @@ Additional uberjar dependencies:
      :real-name                          (get-real-name (:name lein-project))
      :user                               (get-local-ezbake-var lein-project :user
                                                       (:name lein-project))
+     :numeric-uid-gid                    (get-local-ezbake-var lein-project :numeric-uid-gid "nil")
      :group                              (get-local-ezbake-var lein-project :group
                                                       (:name lein-project))
      :uberjar-name                       (:uberjar-name lein-project)


### PR DESCRIPTION
For RPM packaging, we have a reserved uid/gid for the 'puppet' user. To
enable us to use the reserved uid/gid for the puppet user, ezbake needs
to support an option for that. The new option is `numeric-uid-gid`,
which can be set in the `:lein-ezbake` section of your project.clj.

This option is a noop for deb packaging. According to the debian policy
guide
(https://www.debian.org/doc/debian-policy/ch-opersys.html#uid-and-gid-classes)
reserved uids and gids need to be set in the `base-passwd` package.