### PR TITLE
(EZ-129) Set TasksMax for systemd

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
@@ -21,6 +21,15 @@ TimeoutStopSec=<%= EZBake::Config[:stop_timeout] %>
 Restart=on-failure
 StartLimitBurst=5
 PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>.pid
+
+# https://tickets.puppetlabs.com/browse/EZ-129
+# Prior to systemd v228, TasksMax was unset by default, and unlimited. Starting in 228 a default of '512'
+# was implemented. This is low enough to cause problems for certain applications. In systemd 231, the
+# default was changed to be 15% of the default kernel limit. This explicitly sets TasksMax to 4915,
+# which should match the default in systemd 231 and later.
+# See https://github.com/systemd/systemd/issues/3211#issuecomment-233676333
+TasksMax=4915
+
 #set default privileges to -rw-r-----
 UMask=027
 <% if EZBake::Config[:open_file_limit] -%>

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
@@ -21,6 +21,15 @@ TimeoutStopSec=<%= EZBake::Config[:stop_timeout] %>
 Restart=on-failure
 StartLimitBurst=5
 PIDFile=/var/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>.pid
+
+# https://tickets.puppetlabs.com/browse/EZ-129
+# Prior to systemd v228, TasksMax was unset by default, and unlimited. Starting in 228 a default of '512'
+# was implemented. This is low enough to cause problems for certain applications. In systemd 231, the
+# default was changed to be 15% of the default kernel limit. This explicitly sets TasksMax to 4915,
+# which should match the default in systemd 231 and later.
+# See https://github.com/systemd/systemd/issues/3211#issuecomment-233676333
+TasksMax=4915
+
 #set default privileges to -rw-r-----
 UMask=027
 <% if EZBake::Config[:open_file_limit] -%>


### PR DESCRIPTION
In some versions of systemd (including versions in Ubuntu 16.04 and
SLES 12.2) TasksMax deaults to 512. This sets TasksMax for our
services to the default introduced in more recent systemd releases.