### PR TITLE
(SERVER-2399) List JAVA_ARGS_CLI in default file

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -71,6 +71,7 @@ module EZBake
                           },
       :main_namespace => '{{{main-namespace}}}',
       :java_args      => '{{{java-args}}}',
+      :java_args_cli  => '{{{java-args-cli}}}',
       :tk_args        => '{{{tk-args}}}',
       :start_after    => [{{{start-after}}}],
       :replaces_pkgs  => {

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
@@ -8,6 +8,9 @@ JAVA_BIN="/usr/bin/java"
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
 JAVA_ARGS="<%= EZBake::Config[:java_args] %>"
 
+# Modify this as you would JAVA_ARGS but for non-service related subcommands
+JAVA_ARGS_CLI="<%= EZBake::Config[:java_args_cli] %>"
+
 # Modify this if you'd like TrapperKeeper specific arguments
 TK_ARGS="<%= EZBake::Config[:tk_args] %>"
 

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/default.erb
@@ -8,6 +8,9 @@ JAVA_BIN="/opt/puppetlabs/server/bin/java"
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
 JAVA_ARGS="<%= EZBake::Config[:java_args] %>"
 
+# Modify this as you would JAVA_ARGS but for non-service related subcommands
+JAVA_ARGS_CLI="<%= EZBake::Config[:java_args_cli] %>"
+
 # Modify this if you'd like TrapperKeeper specific arguments
 TK_ARGS="<%= EZBake::Config[:tk_args] %>"
 

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -85,6 +85,7 @@
    (schema/optional-key :open-file-limit) schema/Int
    (schema/optional-key :main-namespace) schema/Str
    (schema/optional-key :java-args) schema/Str
+   (schema/optional-key :java-args-cli) schema/Str
    (schema/optional-key :tk-args) schema/Str
    (schema/optional-key :redhat-postinst-install-triggers) RPMTriggers
    (schema/optional-key :redhat-postinst-upgrade-triggers) RPMTriggers
@@ -577,6 +578,8 @@ Additional uberjar dependencies:
                                                       "puppetlabs.trapperkeeper.main")
      :java-args                          (get-local-ezbake-var lein-project :java-args
                                                       "-Xmx192m")
+     :java-args-cli                      (get-local-ezbake-var lein-project :java-args-cli
+                                                      "")
      :tk-args                            (get-local-ezbake-var lein-project :tk-args
                                                        "" )
      ; Convert to string so ruby doesn't barf on the hyphens


### PR DESCRIPTION
Puppet Server at least provides cli tools in addition to ezbake's
provided `start`, `stop`, `reload`. Those tools also need a way to
specify JAVA_ARGS but have Very different needs than the service. Puppet
Server therefore uses JAVA_ARGS_CLI to differentiate between the one
off CLI tools and the service.

This patch adds that JAVA_ARGS_CLI to the default file that ezbake
provides.