### PR TITLE
(EZ-112) Use nss-lookup.target instead of network-online.target

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
@@ -10,7 +10,7 @@
 #
 [Unit]
 Description=<%= EZBake::Config[:project] %> Service
-After=syslog.target network.target network-online.target
+After=syslog.target network.target nss-lookup.target
 
 [Service]
 Type=forking

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
@@ -10,7 +10,7 @@
 #
 [Unit]
 Description=<%= EZBake::Config[:project] %> Service
-After=syslog.target network.target network-online.target <%= EZBake::Config[:start_after].map {|dep| "#{dep}.service" }.join(" ") %>
+After=syslog.target network.target nss-lookup.target <%= EZBake::Config[:start_after].map {|dep| "#{dep}.service" }.join(" ") %>
 
 [Service]
 Type=forking


### PR DESCRIPTION
Users were still seeing errors after the change made here: https://github.com/puppetlabs/ezbake/pull/477. ~~The new change was suggested by Redhat so I'm not sure if we want to use this for debian as well?~~ I've tested with rpms now working on debs and will have info on the tests up in a little bit