### PR TITLE
(PE-24606) use luseradd instead of useradd for ldap reboot issue

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/Rakefile
+++ b/resources/puppetlabs/lein-ezbake/template/global/Rakefile
@@ -1,6 +1,5 @@
 require 'rake'
 require './ezbake.rb'
-require 'libuser'
 
 puts "EZBAKE PROJECT NAME: #{EZBake::Config[:project]}"
 

--- a/resources/puppetlabs/lein-ezbake/template/global/Rakefile
+++ b/resources/puppetlabs/lein-ezbake/template/global/Rakefile
@@ -1,5 +1,6 @@
 require 'rake'
 require './ezbake.rb'
+require 'libuser'
 
 puts "EZBAKE PROJECT NAME: #{EZBake::Config[:project]}"
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/control.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/control.erb
@@ -23,9 +23,9 @@ Architecture: all
      additional_dependencies_string = ", #{EZBake::Config[:debian][:additional_dependencies].join(', ')}"
 end-%>
 <% if EZBake::Config[:is_pe_build] -%>
-Depends: ${misc:Depends}, pe-java, pe-puppet-enterprise-release, net-tools, adduser, procps<%= additional_dependencies_string -%>
+Depends: ${misc:Depends}, pe-java, pe-puppet-enterprise-release, net-tools, libuser, procps<%= additional_dependencies_string -%>
 <% else -%>
-Depends: ${misc:Depends}, openjdk-8-jre-headless | openjdk-11-jre-headless, net-tools, adduser, procps<%= additional_dependencies_string -%>
+Depends: ${misc:Depends}, openjdk-8-jre-headless | openjdk-11-jre-headless, net-tools, libuser, procps<%= additional_dependencies_string -%>
 <% end %>
 Replaces: <%= EZBake::Config[:replaces_pkgs].map {|package, version| "#{package} (<< #{version}-1#{Pkg::Config.packager}1)" }.join(",") %>
 Conflicts: <%= EZBake::Config[:replaces_pkgs].map {|package, version| "#{package} (<< #{version}-1#{Pkg::Config.packager}1)" }.join(",") %>

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/preinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/preinst.erb
@@ -16,7 +16,7 @@ if [ "$1" = install ] || [ "$1" = upgrade ]; then
         --home /opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %> \
         --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
     else
-      useradd -r --gid <%= EZBake::Config[:group] %> \
+      luseradd -r --gid <%= EZBake::Config[:group] %> \
         --home /opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>  --shell $(which nologin) \
         --comment "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :
     fi

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/preinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/preinst.erb
@@ -9,10 +9,10 @@ if [ "$1" = install ] || [ "$1" = upgrade ]; then
     #
     # Add <%= EZBake::Config[:group] %> group
     getent group <%= EZBake::Config[:group] %> > /dev/null || \
-      groupadd -r <%= EZBake::Config[:group] %> || :
+      lgroupadd -r <%= EZBake::Config[:group] %> || :
     # Add <%= EZBake::Config[:user] %> user
-    if getent passwd <%= EZBake::Config[:user] %> > /dev/null; then
-      usermod --gid <%= EZBake::Config[:group] %> \
+    if getent lpasswd <%= EZBake::Config[:user] %> > /dev/null; then
+      lusermod --gid <%= EZBake::Config[:group] %> \
         --home /opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %> \
         --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
     else

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.spec.erb
@@ -100,7 +100,7 @@ BuildRequires:    puppet-agent
 <% else %>
 BuildRequires:    ruby
 <% end -%>
-BuildRequires:    /usr/sbin/useradd
+BuildRequires:    /usr/sbin/luseradd
 %if %{_with_systemd}
 BuildRequires:    systemd
 %endif
@@ -209,10 +209,10 @@ rm -rf $RPM_BUILD_ROOT
 #
 # Add <%= EZBake::Config[:group] %> group
 getent group <%= EZBake::Config[:group] %> > /dev/null || \
-  groupadd -r <%= EZBake::Config[:group] %> || :
+  lgroupadd -r <%= EZBake::Config[:group] %> || :
 # Add <%= EZBake::Config[:user] %> user
-if getent passwd <%= EZBake::Config[:user] %> > /dev/null; then
-  usermod --gid <%= EZBake::Config[:group] %> --home %{_app_data} \
+if getent lpasswd <%= EZBake::Config[:user] %> > /dev/null; then
+  lusermod --gid <%= EZBake::Config[:group] %> --home %{_app_data} \
   --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
 else
   luseradd -r --gid <%= EZBake::Config[:group] %> --home %{_app_data} --shell $(which nologin) \

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.spec.erb
@@ -100,7 +100,7 @@ BuildRequires:    puppet-agent
 <% else %>
 BuildRequires:    ruby
 <% end -%>
-BuildRequires:    /usr/sbin/luseradd
+BuildRequires:    /usr/sbin/useradd
 %if %{_with_systemd}
 BuildRequires:    systemd
 %endif
@@ -140,6 +140,8 @@ Requires:         /usr/bin/which
 
 # procps is required for pgrep, used in several of the init scripts
 Requires:         procps
+# Require libuser for the 'luseradd/lusermod/etc' versions of the user utilities
+Requires:         libuser
 <% EZBake::Config[:redhat][:additional_build_dependencies].each do |dep| %>
 BuildRequires:    <%= dep %>
 <% end %>

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.spec.erb
@@ -215,7 +215,7 @@ if getent passwd <%= EZBake::Config[:user] %> > /dev/null; then
   usermod --gid <%= EZBake::Config[:group] %> --home %{_app_data} \
   --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
 else
-  useradd -r --gid <%= EZBake::Config[:group] %> --home %{_app_data} --shell $(which nologin) \
+  luseradd -r --gid <%= EZBake::Config[:group] %> --home %{_app_data} --shell $(which nologin) \
     --comment "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :
 fi
 <% EZBake::Config[:redhat][:additional_preinst].each do |cmd| -%>

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/preinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/preinst.erb
@@ -19,7 +19,7 @@ else
     useradd_options+=('--uid' '<%= EZBake::Config[:numeric_uid_gid] %>')
   fi
 <% end -%>
-  useradd "${useradd_options[@]}" <%= EZBake::Config[:user] %> || :
+  luseradd "${useradd_options[@]}" <%= EZBake::Config[:user] %> || :
 fi
 <% if defined?(additional_preinst)
 additional_preinst.split(',').each do |cmd| -%>

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/preinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/preinst.erb
@@ -3,19 +3,19 @@
 #
 # Add <%= EZBake::Config[:group] %> group
 <% if EZBake::Config[:numeric_uid_gid].nil? -%>
-getent group <%= EZBake::Config[:group] %> >/dev/null || groupadd --system --force <%= EZBake::Config[:group] %>
+getent group <%= EZBake::Config[:group] %> >/dev/null || lgroupadd --system --force <%= EZBake::Config[:group] %>
 <% else -%>
-getent group <%= EZBake::Config[:group] %> >/dev/null || groupadd --system --force --gid <%= EZBake::Config[:numeric_uid_gid] %> <%= EZBake::Config[:group] %>
+getent group <%= EZBake::Config[:group] %> >/dev/null || lgroupadd --system --force --gid <%= EZBake::Config[:numeric_uid_gid] %> <%= EZBake::Config[:group] %>
 <% end -%>
 
 # Add <%= EZBake::Config[:user] %> user
-if getent passwd <%= EZBake::Config[:user] %> > /dev/null; then
-  usermod --gid <%= EZBake::Config[:group] %> --home %{_app_data} \
+if getent lpasswd <%= EZBake::Config[:user] %> > /dev/null; then
+  lusermod --gid <%= EZBake::Config[:group] %> --home %{_app_data} \
   --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
 else
   useradd_options=('--system' '--gid' '<%= EZBake::Config[:group] %>' '--home' '%{_app_data}' '--shell' "$(which nologin)" '--comment' '<%= EZBake::Config[:project] %> daemon')
 <% unless EZBake::Config[:numeric_uid_gid].nil? -%>
-  if ! getent passwd <%= EZBake::Config[:numeric_uid_gid] %> > /dev/null; then
+  if ! getent lpasswd <%= EZBake::Config[:numeric_uid_gid] %> > /dev/null; then
     useradd_options+=('--uid' '<%= EZBake::Config[:numeric_uid_gid] %>')
   fi
 <% end -%>

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -300,7 +300,7 @@ function task_service_account {
         usermod --gid <%= EZBake::Config[:group] %> --home "${app_data}" \
             --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
     else
-        useradd -r --gid <%= EZBake::Config[:group] %> --home "${app_data}" --shell $(which nologin) \
+        luseradd -r --gid <%= EZBake::Config[:group] %> --home "${app_data}" --shell $(which nologin) \
             --comment "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :
     fi
 }

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -294,10 +294,10 @@ function task_systemd_deb {
 function task_service_account {
     # Add <%= EZBake::Config[:group] %> group
     getent group <%= EZBake::Config[:group] %> > /dev/null || \
-        groupadd -r <%= EZBake::Config[:group] %> || :
+        lgroupadd -r <%= EZBake::Config[:group] %> || :
     # Add or update <%= EZBake::Config[:user] %> user
-    if getent passwd <%= EZBake::Config[:user] %> > /dev/null; then
-        usermod --gid <%= EZBake::Config[:group] %> --home "${app_data}" \
+    if getent lpasswd <%= EZBake::Config[:user] %> > /dev/null; then
+        lusermod --gid <%= EZBake::Config[:group] %> --home "${app_data}" \
             --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
     else
         luseradd -r --gid <%= EZBake::Config[:group] %> --home "${app_data}" --shell $(which nologin) \


### PR DESCRIPTION
Some customers have a requirement to have all locally created users exist in LDAP. Because the same users would be created on every system, the local users for Puppet on a new master already exist in LDAP. The check is performed, the users are determined to already exist, and then during a reboot the systemd-tmpfiles-setup fails due to ldap dependencies of the puppet userid/groups