### PR TITLE
(maint) Honor JAVA_ARGS_CLI values set in the command line

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
@@ -9,7 +9,7 @@ JAVA_BIN="/usr/bin/java"
 JAVA_ARGS="<%= EZBake::Config[:java_args] %>"
 
 # Modify this as you would JAVA_ARGS but for non-service related subcommands
-JAVA_ARGS_CLI="<%= EZBake::Config[:java_args_cli] %>"
+JAVA_ARGS_CLI="${JAVA_ARGS_CLI:-<%= EZBake::Config[:java_args_cli] %>}"
 
 # Modify this if you'd like TrapperKeeper specific arguments
 TK_ARGS="<%= EZBake::Config[:tk_args] %>"


### PR DESCRIPTION
Prior to this we would overwrite any value of JAVA_ARGS_CLI set on the
command line when we sourced the defaults file. This updates the
defaults file to respect any previously set value for the variable.