### PR TITLE
(maint) Fix PE default file to match FOSS wrt JAVA_ARGS_CLI

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/default.erb
@@ -9,7 +9,7 @@ JAVA_BIN="/opt/puppetlabs/server/bin/java"
 JAVA_ARGS="<%= EZBake::Config[:java_args] %>"
 
 # Modify this as you would JAVA_ARGS but for non-service related subcommands
-JAVA_ARGS_CLI="<%= EZBake::Config[:java_args_cli] %>"
+JAVA_ARGS_CLI="${JAVA_ARGS_CLI:-<%= EZBake::Config[:java_args_cli] %>}"
 
 # Modify this if you'd like TrapperKeeper specific arguments
 TK_ARGS="<%= EZBake::Config[:tk_args] %>"


### PR DESCRIPTION
And other tales from "Things You Miss When You Update Work After A Two Week Vacation".