### PR TITLE
(RE-12082) Revert libuser changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.9.7 - 2019-03-04
+This is a bugfix release.
+
+Bugfix:
+  * (RE-12082) Return to using `adduser` commands instead of `libuser` commands.
+    This reverts the work done for PE-24606 in the 1.9.5 release.
+
 ## 1.9.6 - 2019-02-25
 This is a maintenance release.
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/control.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/control.erb
@@ -23,9 +23,9 @@ Architecture: all
      additional_dependencies_string = ", #{EZBake::Config[:debian][:additional_dependencies].join(', ')}"
 end-%>
 <% if EZBake::Config[:is_pe_build] -%>
-Depends: ${misc:Depends}, pe-java, pe-puppet-enterprise-release, net-tools, libuser, procps<%= additional_dependencies_string -%>
+Depends: ${misc:Depends}, pe-java, pe-puppet-enterprise-release, net-tools, adduser, procps<%= additional_dependencies_string -%>
 <% else -%>
-Depends: ${misc:Depends}, openjdk-8-jre-headless | openjdk-11-jre-headless, net-tools, libuser, procps<%= additional_dependencies_string -%>
+Depends: ${misc:Depends}, openjdk-8-jre-headless | openjdk-11-jre-headless, net-tools, adduser, procps<%= additional_dependencies_string -%>
 <% end %>
 Replaces: <%= EZBake::Config[:replaces_pkgs].map {|package, version| "#{package} (<< #{version}-1#{Pkg::Config.packager}1)" }.join(",") %>
 Conflicts: <%= EZBake::Config[:replaces_pkgs].map {|package, version| "#{package} (<< #{version}-1#{Pkg::Config.packager}1)" }.join(",") %>

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/preinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/preinst.erb
@@ -9,14 +9,14 @@ if [ "$1" = install ] || [ "$1" = upgrade ]; then
     #
     # Add <%= EZBake::Config[:group] %> group
     getent group <%= EZBake::Config[:group] %> > /dev/null || \
-      lgroupadd -r <%= EZBake::Config[:group] %> || :
+      groupadd -r <%= EZBake::Config[:group] %> || :
     # Add <%= EZBake::Config[:user] %> user
-    if getent lpasswd <%= EZBake::Config[:user] %> > /dev/null; then
-      lusermod --gid <%= EZBake::Config[:group] %> \
+    if getent passwd <%= EZBake::Config[:user] %> > /dev/null; then
+      usermod --gid <%= EZBake::Config[:group] %> \
         --home /opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %> \
         --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
     else
-      luseradd -r --gid <%= EZBake::Config[:group] %> \
+      useradd -r --gid <%= EZBake::Config[:group] %> \
         --home /opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>  --shell $(which nologin) \
         --comment "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :
     fi

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.spec.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.spec.erb
@@ -140,8 +140,6 @@ Requires:         /usr/bin/which
 
 # procps is required for pgrep, used in several of the init scripts
 Requires:         procps
-# Require libuser for the 'luseradd/lusermod/etc' versions of the user utilities
-Requires:         libuser
 <% EZBake::Config[:redhat][:additional_build_dependencies].each do |dep| %>
 BuildRequires:    <%= dep %>
 <% end %>
@@ -211,13 +209,13 @@ rm -rf $RPM_BUILD_ROOT
 #
 # Add <%= EZBake::Config[:group] %> group
 getent group <%= EZBake::Config[:group] %> > /dev/null || \
-  lgroupadd -r <%= EZBake::Config[:group] %> || :
+  groupadd -r <%= EZBake::Config[:group] %> || :
 # Add <%= EZBake::Config[:user] %> user
-if getent lpasswd <%= EZBake::Config[:user] %> > /dev/null; then
-  lusermod --gid <%= EZBake::Config[:group] %> --home %{_app_data} \
+if getent passwd <%= EZBake::Config[:user] %> > /dev/null; then
+  usermod --gid <%= EZBake::Config[:group] %> --home %{_app_data} \
   --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
 else
-  luseradd -r --gid <%= EZBake::Config[:group] %> --home %{_app_data} --shell $(which nologin) \
+  useradd -r --gid <%= EZBake::Config[:group] %> --home %{_app_data} --shell $(which nologin) \
     --comment "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :
 fi
 <% EZBake::Config[:redhat][:additional_preinst].each do |cmd| -%>

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/preinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/preinst.erb
@@ -3,23 +3,23 @@
 #
 # Add <%= EZBake::Config[:group] %> group
 <% if EZBake::Config[:numeric_uid_gid].nil? -%>
-getent group <%= EZBake::Config[:group] %> >/dev/null || lgroupadd --system --force <%= EZBake::Config[:group] %>
+getent group <%= EZBake::Config[:group] %> >/dev/null || groupadd --system --force <%= EZBake::Config[:group] %>
 <% else -%>
-getent group <%= EZBake::Config[:group] %> >/dev/null || lgroupadd --system --force --gid <%= EZBake::Config[:numeric_uid_gid] %> <%= EZBake::Config[:group] %>
+getent group <%= EZBake::Config[:group] %> >/dev/null || groupadd --system --force --gid <%= EZBake::Config[:numeric_uid_gid] %> <%= EZBake::Config[:group] %>
 <% end -%>
 
 # Add <%= EZBake::Config[:user] %> user
-if getent lpasswd <%= EZBake::Config[:user] %> > /dev/null; then
-  lusermod --gid <%= EZBake::Config[:group] %> --home %{_app_data} \
+if getent passwd <%= EZBake::Config[:user] %> > /dev/null; then
+  usermod --gid <%= EZBake::Config[:group] %> --home %{_app_data} \
   --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
 else
   useradd_options=('--system' '--gid' '<%= EZBake::Config[:group] %>' '--home' '%{_app_data}' '--shell' "$(which nologin)" '--comment' '<%= EZBake::Config[:project] %> daemon')
 <% unless EZBake::Config[:numeric_uid_gid].nil? -%>
-  if ! getent lpasswd <%= EZBake::Config[:numeric_uid_gid] %> > /dev/null; then
+  if ! getent passwd <%= EZBake::Config[:numeric_uid_gid] %> > /dev/null; then
     useradd_options+=('--uid' '<%= EZBake::Config[:numeric_uid_gid] %>')
   fi
 <% end -%>
-  luseradd "${useradd_options[@]}" <%= EZBake::Config[:user] %> || :
+  useradd "${useradd_options[@]}" <%= EZBake::Config[:user] %> || :
 fi
 <% if defined?(additional_preinst)
 additional_preinst.split(',').each do |cmd| -%>

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -294,13 +294,13 @@ function task_systemd_deb {
 function task_service_account {
     # Add <%= EZBake::Config[:group] %> group
     getent group <%= EZBake::Config[:group] %> > /dev/null || \
-        lgroupadd -r <%= EZBake::Config[:group] %> || :
+        groupadd -r <%= EZBake::Config[:group] %> || :
     # Add or update <%= EZBake::Config[:user] %> user
-    if getent lpasswd <%= EZBake::Config[:user] %> > /dev/null; then
-        lusermod --gid <%= EZBake::Config[:group] %> --home "${app_data}" \
+    if getent passwd <%= EZBake::Config[:user] %> > /dev/null; then
+        usermod --gid <%= EZBake::Config[:group] %> --home "${app_data}" \
             --comment "<%= EZBake::Config[:project] %> daemon" <%= EZBake::Config[:user] %> || :
     else
-        luseradd -r --gid <%= EZBake::Config[:group] %> --home "${app_data}" --shell $(which nologin) \
+        useradd -r --gid <%= EZBake::Config[:group] %> --home "${app_data}" --shell $(which nologin) \
             --comment "<%= EZBake::Config[:project] %> daemon"  <%= EZBake::Config[:user] %> || :
     fi
 }


### PR DESCRIPTION
This commit reverts the changes made to address PE-24606. We encountered
installation failure when bumping puppetserver to a version of ezbake with
these changes. There were several issues with this work, the largest of which
being the fact that there is no libuser package for sles and there is a bug in
libuser1, a dependency of libuser, for debian 8 (jessie) and ubuntu 16.04
(xenial) (https://bugs.launchpad.net/ubuntu/+source/system-config-samba/+bug/1718202).
Working around these issues (i.e. only using libuser commands on rhel systems)
is possible, but there are several unused code paths in this repo that are
making this hard to debug. The plan is to remove those paths before retrying
this work.

Revert "add libuser dependency in the correct spot"
This reverts commit c4e988049b128e8bd4f44f59e0cb8969bef3f028.

Revert "add libuser and update commands"
This reverts commit 16c5334a51cb9f7021e74e712814dd330668be63.

Revert "(PE-24606) use luseradd instead of useradd for ldap reboot issue"
This reverts commit 69727d1855f86e00f154ca6e1fab895d7e94be87.