### PR TITLE
(maint) Remove legacy-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,17 +274,6 @@ This will build a container image using the settings in the `:docker` section
 of the `:lein-ezbake` config in `project.clj`. See [Building container images](#building-container-images)
 below for more detail.
 
-#### `legacy-build`
-
-```shell
-lein with-profile ezbake ezbake legacy-build
-```
-
-This will behave exactly like the `build` task in versions of ezbake prior to
-1.6.0.  This will do everything the `stage` action does and then call the external
-builder defined for this project. Currently, the only builder supported is
-[Puppetlabs' Packaging tool](https://github.com/puppetlabs/packaging).
-
 #### `manifest`
 
 ```shell

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -894,14 +894,6 @@ Additional uberjar dependencies:
         rake-call ["bundle" "exec" "rake" "pl:jenkins:trigger_build_local_auth"]]
     (exec/lazy-sh rake-call {:dir staging-dir})))
 
-(defmethod action "legacy-build"
-  [_ lein-project build-target]
-  (action "stage" lein-project build-target)
-  (exec/exec "bundle" "install" "--path" ".bundle/gems" "--binstubs" ".bundle/bin" :dir staging-dir)
-  (let [downstream-job nil
-        rake-call ["bundle" "exec" "rake" "pl:jenkins:uber_build[5]"]]
-    (exec/lazy-sh rake-call {:dir staging-dir})))
-
 (defmethod action "local-build"
   [_ lein-project build-target]
   (action "stage" lein-project build-target)


### PR DESCRIPTION
In 87dcc4da73a9607ba807246c2e53adc84628f416 we removed rpm and deb
packaging artifacts that aren't used by FPM, but we did not remove the
legacy-build action that used those artifacts.

This removes the ability to build packages using anything other than
FPM.