### PR TITLE
(maint) Additional preinstall scripts weren't added properly

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/preinst.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/preinst.erb
@@ -21,8 +21,6 @@ else
 <% end -%>
   useradd "${useradd_options[@]}" <%= EZBake::Config[:user] %> || :
 fi
-<% if defined?(additional_preinst)
-additional_preinst.split(',').each do |cmd| -%>
+<% EZBake::Config[:redhat][:additional_preinst].each do |cmd| -%>
 <%= cmd %>
-<% end -%>
 <% end -%>


### PR DESCRIPTION
It looks like we were treating `additiona_preinst` as a string in the
rpm preinst, but it's an array. Iterate over the array to get these into
the packages correctly.