### PR TITLE
(maint) Use proper file format for random source

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
@@ -28,7 +28,7 @@ if [ -e "$cli_defaults" ]; then
 fi
 
 COMMAND="${JAVA_BIN} ${JAVA_ARGS} ${LOG_APPENDER} \
-         -Djava.security.egd=/dev/urandom \
+         -Djava.security.egd=file:/dev/urandom \
          -cp "$CLASSPATH" \
          clojure.main -m <%= EZBake::Config[:main_namespace] %> \
          --config ${CONFIG} --bootstrap-config ${BOOTSTRAP_CONFIG} \

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -59,7 +59,7 @@ if [ -e "$cli_defaults" ]; then
   fi
 fi
 
-${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=/dev/urandom \
+${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=file:/dev/urandom \
   -XX:OnOutOfMemoryError="kill -9 %p" \
   -cp "${CLASSPATH}" \
   clojure.main \


### PR DESCRIPTION
On OpenJDK 8 the security.egd and securerandom.sourcefile parameters,
if set, should have a protocol attached their path. When using
`-Djava.security.debug=provider` one can see this error with the
previous value:

```
puppetserver[24654]: provider: Failed to create seed generator with /dev/urandom: java.net.MalformedURLException: no protocol: /dev/urandom
```

With this change service start up time (measure with just
`while true; do time systemctl restart puppetserver; done`)
goes from 27 seconds on redhat 7 to 20 seconds and from 23 seconds on
debian 8 to 18 seconds.

I should note that removing this line completely also has the same
effect. It appears that in OpenJDK 8 and above the JVM simply does the
right thing. Instead of removing the line I've left if for FOSS users
that may be using our software on other implementations/OSes.