### PR TITLE
(maint) Add docker container for ezbake builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*
+!project.clj
+!docker
+!resources
+!src

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ target
 /template/ext/packaging
 .nrepl-port
 .lein-failures
+Gemfile.lock
+.bundle

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -1,0 +1,7 @@
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
+
+gem 'rspec'
+gem 'pupperware',
+    :git => 'https://github.com/puppetlabs/pupperware.git',
+    :branch => 'master',
+    :glob => 'gem/*.gemspec'

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -26,13 +26,13 @@ else
 endif
 
 build: prep
-	  @docker build \
-			--pull \
-			--build-arg vcs_ref=$(vcs_ref) \
-			--build-arg build_date=$(build_date) \
-			--build-arg version=$(version) \
-			--file ezbake/$(dockerfile) \
-			--tag $(NAMESPACE)/ezbake:$(version) $(pwd)/..
+	@docker build \
+		--pull \
+		--build-arg vcs_ref=$(vcs_ref) \
+		--build-arg build_date=$(build_date) \
+		--build-arg version=$(version) \
+		--file ezbake/$(dockerfile) \
+		--tag $(NAMESPACE)/ezbake:$(version) $(pwd)/..
 ifeq ($(IS_LATEST),true)
 	@docker tag $(NAMESPACE)/ezbake:$(version) $(NAMESPACE)/ezbake:latest
 endif

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,51 @@
+NAMESPACE ?= puppet
+git_describe := $(shell git describe)
+vcs_ref := $(shell git rev-parse HEAD)
+build_date := $(shell date -u +%FT%T)
+hadolint_available := $(shell hadolint --help > /dev/null 2>&1; echo $$?)
+hadolint_command := hadolint --ignore DL3008 --ignore DL3018 --ignore DL3028 --ignore DL4000 --ignore DL4001
+hadolint_container := hadolint/hadolint:latest
+pwd := $(shell pwd)
+export BUNDLE_PATH = $(pwd)/.bundle/gems
+export BUNDLE_BIN = $(pwd)/.bundle/bin
+export GEMFILE = $(pwd)/Gemfile
+
+version := $(shell echo $(git_describe) | sed 's/-.*//')
+dockerfile := Dockerfile
+
+prep:
+	@git fetch --unshallow 2> /dev/null ||:
+	@git fetch origin 'refs/tags/*:refs/tags/*'
+
+lint:
+ifeq ($(hadolint_available),0)
+	@$(hadolint_command) ezbake/$(dockerfile)
+else
+	@docker pull $(hadolint_container)
+	@docker run --rm -v $(PWD)/ezbake/$(dockerfile):/Dockerfile -i $(hadolint_container) $(hadolint_command) Dockerfile
+endif
+
+build: prep
+	  @docker build \
+			--pull \
+			--build-arg vcs_ref=$(vcs_ref) \
+			--build-arg build_date=$(build_date) \
+			--build-arg version=$(version) \
+			--file ezbake/$(dockerfile) \
+			--tag $(NAMESPACE)/ezbake:$(version) $(pwd)/..
+ifeq ($(IS_LATEST),true)
+	@docker tag $(NAMESPACE)/ezbake:$(version) $(NAMESPACE)/ezbake:latest
+endif
+
+test: prep
+	@bundle install --path $$BUNDLE_PATH --gemfile $$GEMFILE
+	@PUPPET_TEST_DOCKER_IMAGE=$(NAMESPACE)/ezbake:$(version) \
+		bundle exec --gemfile $$GEMFILE rspec spec
+
+publish: prep
+	@docker push $(NAMESPACE)/ezbake:$(version)
+ifeq ($(IS_LATEST),true)
+	@docker push $(NAMESPACE)/ezbake:latest
+endif
+
+.PHONY: prep lint build test publish

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,136 @@
+# [puppetlabs/ezbake](https://github.com/puppetlabs/ezbake)
+
+The Dockerfile for this image is available in the ezbake repository [here][1].
+
+This container will let you build custom packages for projects using ezbake,
+including PuppetServer and PuppetDB.
+
+## Configuration
+
+The following environment variables are supported:
+
+- `EZBAKE_ALLOW_UNREPRODUCIBLE_BUILDS`
+
+  Allow ezbake to use locally-hosted SNAPSHOT builds rather than requiring
+  they come from a configured snapshots repository. Defaults to `true`
+
+- `EZBAKE_NODEPLOY`
+
+  Do not deploy SNAPSHOT builds to a configured snapshots repository. Defaults
+  to `true`
+
+- `GEM_SOURCE`
+
+  The rubygems host you want to point to. Defaults to `https://rubygems.org`
+
+- `LEIN_PROFILES`
+
+  The lein profiles to use to build your package. Use a comma-separated list for multiple
+  profiles. Defaults to `ezbake`
+
+- `EZBAKE_REPO`
+
+  The URL for the repo of your custom ezbake. i.e., `https://github.com/puppetlabs/ezbake`.
+  Unset by default
+
+- `EZBAKE_BRANCH`
+
+  The branch you want to build your custom ezbake from. Unset by default. You should only
+  set one of `EZBAKE_BRANCH` and `EZBAKE_REF`
+
+- `EZBAKE_REF`
+
+  The git ref you want to build your custom ezbake from. Unset by default. You should only
+  set one of `EZBAKE_BRANCH` and `EZBAKE_REF`
+
+- `PROJECT_REPO`
+
+  The URL for the repo you're building. i.e., `https://github.com/underscorgan/puppetdb`.
+  Unset by default
+
+- `PROJECT_BRANCH`
+
+  The branch you want to build your packages from. Unset by default. You should only set
+  one of `PROJECT_BRANCH` and `PROJECT_REF`
+
+- `PROJECT_REF`
+
+  The git ref you want to build your packages from. Unset by default. You should only set
+  one of `PROJECT_BRANCH` and `PROJECT_REF`
+
+- `MOCK`
+
+  *NOTE* `MOCK` and `COW` have some weird requirements tied to assumptions in the [packaging repo](https://github.com/puppetlabs/packaging). There's a plan to make this better at some point.
+
+  The rpm platforms you want to build. Individual entries must match the pattern
+  `pl-<os>-<version>-<arch>`. For multiple OSes, use a space separated list. Defaults to
+  `pl-el-6-i386 pl-el-7-x86_64 pl-el-8-x86_64 pl-redhatfips-7-x86_64 pl-sles-12-x86_64`
+
+- `COW`
+
+  *NOTE* `MOCK` and `COW` have some weird requirements tied to assumptions in the [packaging repo](https://github.com/puppetlabs/packaging). There's a plan to make this better at some point.
+
+  The deb platforms you want to build. Individual entries must match the pattern
+  `base-<codename>-<arch>.cow`. For multiple OSes, use a space separated list. Defaults to 
+  `base-jessie-i386.cow base-xenial-i386.cow base-stretch-i386.cow base-bionic-i386.cow`
+
+- `UPDATE_EZBAKE_VERSION`
+
+  Whether or not to update the ezbake version in the project you're building. This is
+  mostly intended to let you test ezbake changes without having to commit code with a `-SNAPSHOT`
+  version in project.clj. Defaults to false
+
+- `EZBAKE_VERSION`
+
+  The version of ezbake to use for your build. Only does anything if `UPDATE_EZBAKE_VERSION`
+  is set to true. Defaults to unset
+
+
+## Running
+
+There are a few different ways I've found for running builds on this container. I'll document
+the pros and cons here.
+
+This container assumes that the code you're building will be in `/workspace`. The packages
+will be copied into `/output` before the container terminates, and if you're building a
+custom ezbake that will be cloned into `/ezbake`.
+
+1. Run from a remotely accessible repo (github, gitlab, etc)
+
+This is by far the fastest build option, but does require the extra step of committing and pushing your code
+rather than using the code in your working dir.
+
+```
+docker run --rm --volume $(PWD)/output:/output --env PROJECT_REPO=https://github.com/underscorgan/puppetdb --env PROJECT_BRANCH=my_feature_branch puppet/ezbake
+```
+
+2. Mount in your current working directory
+
+    * Please note: due to the amount of I/O used in compiling the artifacts it will be _incredibly_ slow if you
+mount in your entire current working directory. The options below will speed it up significantly (I haven't
+actually managed to get a build to finish and have killed it after ~30 minutes when I've mounted in my whole
+working directory), but it still takes significantly more than the builds from remote repo. The options are:
+
+    a. Mount in full working directory and use anonymous volumes for the I/O heavy directories
+
+    This is the slower of the two options, but also the simplest. The volumes in the example should be the
+    same for all ezbake projects.
+
+    ```
+    docker run --rm --volume $(PWD)/output:/output --volume /workspace/test --volume /workspace/test-resources --volume /workspace/target --volume /workspace/tmp puppet/ezbake
+    ```
+    
+    b. Only mount in needed files/directories
+
+    This is faster than mounting in everything and using anonymous volumes, but it'll take more effort
+    to get the correct things mounted in. This will vary some between projects, but you can get a pretty
+    good idea of what is needed by looking at the `.gitignore` or `.dockerignore` files.
+
+    *NOTE* you will always need to mount in `.git` so the packaging can figure out what version it's supposed
+    to be (uses `git describe`).
+
+    ```
+    docker run --rm --volume $(PWD)/output:/output --volume $(PWD)/src:/workspace/src --volume $(PWD)/project.clj:/workspace/project.clj --volume $(PWD)/resources:/workspace/resources --volume $(PWD)/.git:/workspace/.git puppet/ezbake
+    ```
+
+[1]: https://github.com/puppetlabs/ezbake/blob/master/docker/ezbake/Dockerfile

--- a/docker/distelli-manifest.yml
+++ b/docker/distelli-manifest.yml
@@ -1,0 +1,9 @@
+release-engineering/ezbake:
+  PreBuild:
+    - make lint
+  Build:
+    - make build
+    - make test
+  AfterBuildSuccess:
+    - docker login -u "$DISTELLI_DOCKER_USERNAME" -p "$DISTELLI_DOCKER_PW" "$DISTELLI_DOCKER_ENDPOINT"
+    - make publish

--- a/docker/ezbake/Dockerfile
+++ b/docker/ezbake/Dockerfile
@@ -1,0 +1,70 @@
+FROM centos:7 as build
+ARG ruby_major_ver=2.6
+ARG ruby_patch_ver=2
+ENV ruby_ver="$ruby_major_ver.$ruby_patch_ver"
+
+RUN yum -y groupinstall "Development Tools" && \
+    yum -y install wget openssl-devel
+
+RUN wget "http://cache.ruby-lang.org/pub/ruby/$ruby_major_ver/ruby-$ruby_ver.tar.gz" && \
+    tar xf "ruby-$ruby_ver.tar.gz"
+
+WORKDIR /ruby-$ruby_ver
+RUN ./configure && \
+    make && \
+    make install
+
+FROM centos:7
+
+ARG sles_12_mirror=http://osmirror.delivery.puppetlabs.net/sles-12-sp2-x86_64/RPMS.os
+ARG version="2.0.4"
+ARG vcs_ref
+ARG build_date
+
+ENV EZBAKE_ALLOW_UNREPRODUCIBLE_BUILDS=true
+ENV EZBAKE_NODEPLOY=true
+ENV EZBAKE_VERSION="$version"
+ENV GEM_SOURCE=https://rubygems.org
+ENV LEIN_PROFILES=ezbake
+
+LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
+      org.label-schema.url="https://github.com/puppetlabs/ezbake" \
+      org.label-schema.name="ezbake" \
+      org.label-schema.license="Apache-2.0" \
+      org.label-schema.version="$EZBAKE_VERSION" \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/ezbake" \
+      org.label-schema.vcs-ref="$vcs_ref" \
+      org.label-schema.build-date="$build_date" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.dockerfile="/Dockerfile"
+
+COPY --from=build /usr/local/bin /usr/local/bin
+COPY --from=build /usr/local/include /usr/local/include
+COPY --from=build /usr/local/lib /usr/local/lib
+COPY --from=build /usr/local/share /usr/local/share
+
+RUN yum clean all && \
+    yum install --assumeyes rpm-build java-1.8.0-openjdk-devel git curl ruby ruby-devel gcc-c++ make zlib-devel && \
+    yum localinstall --assumeyes $sles_12_mirror/systemd-rpm-macros-3-8.374.noarch.rpm && \
+    git config --global user.name "Puppet Release Team" && \
+    git config --global user.email "release@puppet.com"
+RUN curl --output /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
+    chmod 0755 /usr/local/bin/lein && \
+    /usr/local/bin/lein
+RUN gem install --no-doc bundler fpm && \
+    mkdir /workspace && \
+    mkdir /ezbake_src
+COPY docker/ezbake/docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+
+# Have the latest ezbake installed 
+COPY . /ezbake_src
+WORKDIR /ezbake_src
+RUN lein clean && lein install
+
+WORKDIR /
+
+ENTRYPOINT ["/docker-entrypoint.sh"] 
+
+COPY docker/ezbake/Dockerfile /

--- a/docker/ezbake/docker-entrypoint.sh
+++ b/docker/ezbake/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+if [ -n "$EZBAKE_REPO" ]; then
+  git clone $EZBAKE_REPO /ezbake
+  cd /ezbake
+  if [ -n "$EZBAKE_BRANCH" ]; then
+    git checkout origin/$EZBAKE_BRANCH
+  elif [ -n "$EZBAKE_REF" ]; then
+    git checkout $EZBAKE_REF
+  fi
+  lein clean && lein install
+fi
+
+if [ -n "$PROJECT_REPO" ]; then
+  git clone $PROJECT_REPO /workspace
+  cd /workspace
+  if [ -n "$PROJECT_BRANCH" ]; then
+    git checkout origin/$PROJECT_BRANCH
+  elif [ -n "$PROJECT_REF" ]; then
+    git checkout $PROJECT_REF
+  fi
+fi
+
+cd /workspace
+
+if [ "$UPDATE_EZBAKE_VERSION" == 'true' ]; then
+  if [ -z "$EZBAKE_VERSION" ]; then
+    echo '$EZBAKE_VERSION is required when $UPDATE_EZBAKE_VERSION=true'
+    exit 1
+  fi
+
+  echo "Building with ezbake version $EZBAKE_VERSION"
+  sed -i "s|puppetlabs/lein-ezbake \".*\"|puppetlabs/lein-ezbake \"$EZBAKE_VERSION\"|" project.clj
+fi
+
+lein clean && lein install
+
+lein with-profile $LEIN_PROFILES ezbake local-build
+rsync -a output/ /output/

--- a/docker/spec/ezbake_spec.rb
+++ b/docker/spec/ezbake_spec.rb
@@ -1,0 +1,49 @@
+require 'rspec/core'
+require 'fileutils'
+require 'open3'
+require 'pupperware/spec_helper'
+
+SPEC_DIRECTORY = File.dirname(__FILE__)
+DOCKER_DIRECTORY = File.dirname(SPEC_DIRECTORY)
+EZBAKE_DIRECTORY = File.dirname(DOCKER_DIRECTORY)
+
+describe 'ezbake_container' do
+  include Pupperware::SpecHelpers
+
+  def run_build(repo, branch)
+    run_command("docker run --detach \
+                   --env PROJECT_REPO=#{repo} \
+                   --env PROJECT_BRANCH=#{branch} \
+                   --env UPDATE_EZBAKE_VERSION=true \
+                   --env EZBAKE_VERSION=#{@ezbake_version} \
+                   #{@image}")
+  end
+
+  before(:all) do
+    @image = require_test_image
+    # the version in ezbake's project.clj looks like
+    #    (defproject puppetlabs/lein-ezbake "2.0.4-SNAPSHOT"
+    # Look for that line and parse out the version string for use in the builds
+    @ezbake_version = File.open(File.join(EZBAKE_DIRECTORY, "project.clj")) do |f|
+      /.* "(.*)"/.match(f.grep(/defproject/).first.chomp)[1]
+    end
+  end
+
+  it 'should be able to build puppetserver' do
+    result = run_build('https://github.com/puppetlabs/puppetserver', 'master')
+    container = result[:stdout].chomp
+    wait_on_container_exit(container, 450)
+    expect(get_container_exit_code(container)).to eq(0)
+    emit_log(container)
+    teardown_container(container)
+  end
+
+  it 'should be able to build puppetdb' do
+    result = run_build('https://github.com/puppetlabs/puppetdb', 'master')
+    container = result[:stdout].chomp
+    wait_on_container_exit(container, 450)
+    expect(get_container_exit_code(container)).to eq(0)
+    emit_log(container)
+    teardown_container(container)
+ end
+end


### PR DESCRIPTION
This commit adds artifacts needed to build and test an ezbake container.
This should help with development and testing, both internal to Puppet
and for external contributors.