### PR TITLE
(SERVER-2602) Do not manage egd

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
@@ -28,7 +28,6 @@ if [ -e "$cli_defaults" ]; then
 fi
 
 COMMAND="${JAVA_BIN} ${JAVA_ARGS} ${LOG_APPENDER} \
-         -Djava.security.egd=file:/dev/urandom \
          -cp "$CLASSPATH" \
          clojure.main -m <%= EZBake::Config[:main_namespace] %> \
          --config ${CONFIG} --bootstrap-config ${BOOTSTRAP_CONFIG} \

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -59,7 +59,7 @@ if [ -e "$cli_defaults" ]; then
   fi
 fi
 
-${JAVA_BIN} ${JAVA_ARGS} -Djava.security.egd=file:/dev/urandom \
+${JAVA_BIN} ${JAVA_ARGS} \
   -XX:OnOutOfMemoryError="kill -9 %p" \
   -cp "${CLASSPATH}" \
   clojure.main \


### PR DESCRIPTION
This setting is of little value in Java 8+ and we've seen no difference
anecdotally between explicitly configuring /dev/urandom as a source vs
using the JVMs defaults.

We will be explicitly setting this to /dev/random for FIPS enabled
builds, however we will do so via the JAVA_ARGS variable. FOSS users who
would like to manage their egd source should use JAVA_ARGS as well.