### PR TITLE
(maint) fix up deprecation warning

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/tasks/build.rake
+++ b/resources/puppetlabs/lein-ezbake/template/global/tasks/build.rake
@@ -18,7 +18,7 @@ namespace :pl do
   task :local_build => "pl:fetch" do
     # If we have a dirty source, bail, because changes won't get reflected in
     # the package builds
-    Pkg::Util::Version.fail_on_dirty_source
+    Pkg::Util::Git.fail_on_dirty_source
 
     Pkg::Util::RakeUtils.invoke_task("package:tar")
     # where we want the packages to be copied to for the local build


### PR DESCRIPTION
!! Pkg::Util::Version.fail_on_dirty_source is deprecated. Please use
Pkg::Util::Git.fail_on_dirty_source instead.