### PR TITLE
(maint) Remove redhatfips-7-x86_64 from foss build_defaults

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -6,7 +6,7 @@ packager: 'puppetlabs'
 gpg_key: '7F438280EF8D349F'
 sign_tar: FALSE
 # a space separated list of mock configs
-final_mocks: 'pl-el-6-i386 pl-el-7-x86_64 pl-el-8-x86_64 pl-redhatfips-7-x86_64 pl-sles-12-x86_64'
+final_mocks: 'pl-el-6-i386 pl-el-7-x86_64 pl-el-8-x86_64 pl-sles-12-x86_64'
 yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: FALSE


### PR DESCRIPTION
This commit removes redhatfips as a default platform for FOSS projects. As far
as I'm aware, we are only supporting FIPS masters for PE customers.