### PR TITLE
Revert "(maint) Add rng-tools as a dependency on redhatfips"

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -216,10 +216,6 @@ if options.output_type == 'rpm'
     fpm_opts << "--depends systemd"
   end
 
-  if options.operating_system == :redhatfips
-    fpm_opts << "--depends rng-tools"
-  end
-  
   if options.systemd_sles == 1
     fpm_opts << "--rpm-tag '%{?systemd_requires}'"
   end


### PR DESCRIPTION
Reverts puppetlabs/ezbake#561

We have added these tools to our test pipelines, we don't need to depend on them in the packages