### PR TITLE
Revert "(maint) Update changelog for 2.1.6 release"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [2.1.6] - 2019-10-10
-This is a maintenance release.
-
-Maintenance:
-  * Add dependency on `rng-tools` for redhatfips platforms.
-
 ## [2.1.5] - 2019-10-08
 This is a maintenance release.
 
@@ -756,8 +750,7 @@ This release contains bug fixes and AIO path changes.
 ## 0.1.0 - 2015-01-13
  * Rewrite ezbake to follow leiningen plugin application model.
 
-[Unreleased]: https://github.com/puppetlabs/ezbake/compare/2.1.6...HEAD
-[2.1.6]: https://github.com/puppetlabs/ezbake/compare/2.1.5...2.1.6
+[Unreleased]: https://github.com/puppetlabs/ezbake/compare/2.1.5...HEAD
 [2.1.5]: https://github.com/puppetlabs/ezbake/compare/2.1.4...2.1.5
 [2.1.4]: https://github.com/puppetlabs/ezbake/compare/2.1.3...2.1.4
 [2.1.3]: https://github.com/puppetlabs/ezbake/compare/2.1.2...2.1.3


### PR DESCRIPTION
This reverts commit fe5919e5a52ba3b7e6f20b5e7a6fbfaa2006f46e.
This version was never released because we ended up reverting the only change
it would have included.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.