### PR TITLE
(RE-12523) Don't set `TasksMax` in the service file for Debian 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+Bugfix:
+  * (RE-12523) Don't set `TasksMax` in the Debian 8 service file since that option
+    is not supported by the included version of systemd.
 
 ## [2.1.5] - 2019-10-08
 This is a maintenance release.

--- a/resources/puppetlabs/lein-ezbake/template/global/controller.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/controller.sh.erb
@@ -47,6 +47,10 @@ if [ -d ext/docs ]; then
                         cp -r "$basepath/base_deb" "$basepath/systemd_deb"
                         DESTDIR="$basepath/systemd_deb" bash install.sh systemd_deb
                 fi
+                if [ ! -d "$basepath/systemd_notasksmax_deb" ]; then
+                        cp -r "$basepath/base_deb" "$basepath/systemd_notasksmax_deb"
+                        DESTDIR="$basepath/systemd_notasksmax_deb" USE_TASKSMAX=false bash install.sh systemd_deb
+                fi
                 if [ ! -d "$basepath/sysvinit_deb" ]; then
                         cp -r "$basepath/base_deb" "$basepath/sysvinit_deb"
                         DESTDIR="$basepath/sysvinit_deb" bash install.sh sysv_init_deb
@@ -56,6 +60,10 @@ else
         if [ ! -d "$basepath/systemd_deb" ]; then
                 cp -r "$basepath/base" "$basepath/systemd_deb"
                 DESTDIR="$basepath/systemd_deb" bash install.sh systemd_deb
+        fi
+        if [ ! -d "$basepath/systemd_notasksmax_deb" ]; then
+                cp -r "$basepath/base" "$basepath/systemd_notasksmax_deb"
+                DESTDIR="$basepath/systemd_notasksmax_deb" USE_TASKSMAX=false bash install.sh systemd_deb
         fi
         if [ ! -d "$basepath/sysvinit_deb" ]; then
                 cp -r "$basepath/base" "$basepath/sysvinit_deb"
@@ -76,6 +84,10 @@ case $os in
         debian|ubuntu)
                 if [ "$os_dist" = 'trusty' ]; then
                         dir="$basepath/sysvinit_deb"
+                elif [ "$os_dist" = 'jessie' ]; then
+                        # the version of systemd that ships with jessie doesn't
+                        # support TasksMax
+                        dir="$basepath/systemd_notasksmax_deb"
                 else
                         dir="$basepath/systemd_deb"
                 fi

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -6,6 +6,8 @@ if [ -n "${EZ_VERBOSE}" ]; then
     set -x
 fi
 
+USE_TASKSMAX=${USE_TASKSMAX:-true}
+
 # Warning: This variable API is experimental so these variables may be subject
 # to change in the future.
 prefix=${prefix:=/usr}
@@ -287,6 +289,9 @@ function task_systemd_deb {
     task sysv_init_deb
     install -d -m 0755 "${DESTDIR}${unitdir_debian}"
     install -m 0644 ext/debian/<%= EZBake::Config[:project] %>.service_file "${DESTDIR}${unitdir_debian}/<%= EZBake::Config[:project] %>.service"
+    if [ "$USE_TASKSMAX" == "false" ]; then
+      sed -i "s/^TasksMax/# Don't set TasksMax since the option doesn't exist\n# TasksMax/" "${DESTDIR}${unitdir_debian}/<%= EZBake::Config[:project] %>.service"
+    fi
     install -d -m 0755 "${DESTDIR}${tmpfilesdir}"
     install -m 0644 ext/<%= EZBake::Config[:project] %>.tmpfiles.conf "${DESTDIR}${tmpfilesdir}/<%= EZBake::Config[:project] %>.conf"
 }


### PR DESCRIPTION
This option isn't supported with the version of systemd that ships with
Debian 8, so comment out that line at install time.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.