### PR TITLE
(EZ-135) PE packages should depend on pe-bouncy-castle-jars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+Bugfix:
+  * (EZ-135) PE packages should have a dependency on pe-bouncy-castle-jars.
 
 ## [2.1.6] - 2020-02-11
 This is a bugfix release.

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -346,6 +346,7 @@ end
 if options.is_pe
   fpm_opts << "--depends pe-java"
   fpm_opts << "--depends pe-puppet-enterprise-release"
+  fpm_opts << "--depends pe-bouncy-castle-jars"
 else
   fpm_opts << "--depends #{options.java}"
 end


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.