### PR TITLE
(EZ-35) Make use of project build-scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+Bugfix:
+  * (EZ-35) Make use of project build-scripts, in addition to dependency build-scripts.
 
 ## [2.1.7] - 2020-06-16
 Bugfix:

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -322,6 +322,13 @@ Additional uberjar dependencies:
     ;; Return just a list of the files
     (mapcat last files)))
 
+(defn cp-project-build-scripts
+  "Copy build-scripts in the project directory into the staging directory"
+  [lein-project]
+  ;; TODO: try all resource-paths, not just first
+  (let [project-resource-path (first (get lein-project :resource-paths))]
+    (fs/copy-dir-into (fs/file project-resource-path build-scripts-prefix) (fs/file staging-dir build-scripts-prefix))))
+
 (schema/defn cp-to-staging-dir :- File
   "Copy a file to the staging directory"
   [config-dir :- File
@@ -900,6 +907,7 @@ Additional uberjar dependencies:
           timestamp (get-timestamp-string)]
       (cp-shared-files dependencies get-cli-defaults-files-in)
       (cp-shared-files dependencies get-build-scripts-files-in)
+      (cp-project-build-scripts lein-project)
       (if cli-app-files
         (cp-cli-wrapper-scripts (:name lein-project)))
       (cp-doc-files lein-project)


### PR DESCRIPTION
This commit adds a method to copy build-scripts from the current project to the
staging dir. Previously, we only copied build-scripts from direct dependencies,
which resulted in the FOSS puppetserver build-scripts to be used instead of the
pe-puppet-server-extensions build-scripts when building from pe-pse instead of
from pe-puppetserver (PE-28810).

It appears that puppetserver gets around this by declaring a dependency on
itself in the :ezbake profile.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.