### PR TITLE
(EZ-142) Fix OnOutOfMemoryError flag used for older Javas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+Bugfix:
+  * (EZ-142) Fix quoting of `-XX:OnOutOfMemoryError` argument added in 2.2.1.
 
 ## [2.2.2] - 2021-02-19
 Added:

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/start.erb
@@ -63,7 +63,7 @@ fi
 java_version=$($JAVA_BIN -version 2>&1 | head -1 | awk -F\" '{ print $2 }')
 java_major_version=$(echo $java_version | awk -F. '{ print $1 }')
 
-out_of_memory_flag='-XX:OnOutOfMemoryError="kill -9 %p"'
+out_of_memory_flag='-XX:OnOutOfMemoryError=kill -9 %p'
 if [ "$java_major_version" -ge 11 ]; then
   out_of_memory_flag="-XX:+CrashOnOutOfMemoryError"
 fi


### PR DESCRIPTION
This commit makes a small correction to the OnOutOfMemoryError flag
used when starting JVMs when the Java version is older than 11.
Prior to this commit, the nested quoting of the argument for the
OnOutOfMemoryError flag resulted in Java attempting to execute
"kill -9 %p" as a single binary name instead of executing "kill"
and passing "-9" and "%p" as arguments.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.