### PR TITLE
(REPLATS-150) Skip efforts to run as user when already service user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [Unreleased]
 Bugfix:
   * (EZ-142) Fix quoting of `-XX:OnOutOfMemoryError` argument added in 2.2.1.
+  * (REPLATS-150) Skip efforts to run as user when already service user.
+    In this case, the foreground command is already being executed as the
+    service user and attempts to become that user fail as it doesn't have
+    privileges to redundantly become itself anyway.
 
 ## [2.2.2] - 2021-02-19
 Added:

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
@@ -38,6 +38,8 @@ COMMAND="${JAVA_BIN} ${JAVA_ARGS} ${LOG_APPENDER} \
 pushd "${INSTALL_DIR}" &> /dev/null
 if [ "$EUID" = "0" ] && command -v runuser &> /dev/null; then
   runuser "${USER}" -s /bin/bash -c "$COMMAND"
+elif [ "$EUID" = "$(id -u ${USER})" ]; then
+  /bin/bash -c "$COMMAND"
 elif command -v sudo &> /dev/null; then
   sudo -H -u "${USER}" $COMMAND
 else


### PR DESCRIPTION
Ran into this adjusting k8s pods to runas the service user. In this
case, the foreground command is already being executed as the service
user and attempts to become that user fail as it doesn't have privileges
to redundantly become itself anyway.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.