### PR TITLE
(EZ-145) Remove debian 8 from build targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+Removed:
+  * Removed debian 8 from build targets
+
 Added:
   * Use sha256 digests for rpm packages.
 

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -1,6 +1,6 @@
 ---
-default_cow: 'base-jessie-i386.cow'
-cows: 'base-jessie-i386.cow base-xenial-i386.cow base-stretch-i386.cow base-bionic-i386.cow base-buster-i386.cow base-focal-i386.cow'
+default_cow: 'base-bionic-i386.cow'
+cows: 'base-xenial-i386.cow base-stretch-i386.cow base-bionic-i386.cow base-buster-i386.cow base-focal-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_key: '4528B6CD9E61EF26'


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.