### PR TITLE
(RE-14469) Add debian 11 as a default FOSS platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Removed:
 
 Added:
   * Use sha256 digests for rpm packages.
+  * Add debian 11 to build targets
 
 Bugfix:
   * (EZ-137) Changed templates to use /run directory instead of /var/run directory for PIDFiles except for with el-6 platform.

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -1,6 +1,6 @@
 ---
 default_cow: 'base-bionic-i386.cow'
-cows: 'base-xenial-i386.cow base-stretch-i386.cow base-bionic-i386.cow base-buster-i386.cow base-focal-i386.cow'
+cows: 'base-xenial-i386.cow base-stretch-i386.cow base-bionic-i386.cow base-buster-i386.cow base-focal-i386.cow base-bullseye-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_key: '4528B6CD9E61EF26'

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -288,7 +288,7 @@ elsif options.output_type == 'deb'
   end
   options.java = 'openjdk-8-jre-headless'
 
-  if options.dist == 'buster' # debian 10 uses java11
+  if options.dist =~ /buster|bullseye/ # debian 10+ uses java11
     options.java = 'openjdk-11-jre-headless'
   end
 


### PR DESCRIPTION
Debian 11 is not able to easily install Java 8, so like Debian 10 and
Ubunutu 20.04, we make packages depend on Java 11 instead.