### PR TITLE
(PE-34455) Add nrepl/nrepl to exclusion list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [2.3.3] - 2022-10-26
+Maintenance:
+  * (PE-34484) Add nrepl/nrepl to exclusions list
+
 Removed:
   * Removed debian 9 from build targets
 

--- a/src/puppetlabs/ezbake/dependency_utils.clj
+++ b/src/puppetlabs/ezbake/dependency_utils.clj
@@ -17,6 +17,7 @@
 ;; it automatically adds these dependencies to the dependency list, and these
 ;; are not at all relevant to our task at hand.
 (def exclude-dependencies #{'org.clojure/tools.nrepl
+                            'nrepl/nrepl
                             'clojure-complete/clojure-complete})
 
 (defn include-dep?


### PR DESCRIPTION
https://github.com/puppetlabs/trapperkeeper/commit/f0c51cf3f8ce4e2d29f268ffed63b514348e43f9 added nrepl/nrepl to trapperkeeper, replacing org.clojure/tools.nrepl, but the ezbake exclusion was not updated, so nrepl is being included in built packages. While not enabled by default, this is a bit of a security risk, so we should exclude nrepl/nrepl as well.