### PR TITLE
(maint) Removded pl-el-6-i386 and base-xenial-i386.cow as build defaults for foss.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 Removed:
-  * Removed debian 9 from build targets
+  * (EZ-149) Removed debian 9 from build targets
+  * (maint) Removed pl-el-6-i386 and base-xenial-i386.cow as build defaults for foss.
 
 ## [2.3.2] - 2022-02-15
 Added:

--- a/docker/README.md
+++ b/docker/README.md
@@ -64,7 +64,7 @@ The following environment variables are supported:
 
   The rpm platforms you want to build. Individual entries must match the pattern
   `pl-<os>-<version>-<arch>`. For multiple OSes, use a space separated list. Defaults to
-  `pl-el-6-i386 pl-el-7-x86_64 pl-el-8-x86_64 pl-redhatfips-7-x86_64 pl-sles-12-x86_64`
+  `pl-el-7-x86_64 pl-el-8-x86_64 pl-redhatfips-7-x86_64 pl-sles-12-x86_64`
 
 - `COW`
 
@@ -72,7 +72,7 @@ The following environment variables are supported:
 
   The deb platforms you want to build. Individual entries must match the pattern
   `base-<codename>-<arch>.cow`. For multiple OSes, use a space separated list. Defaults to 
-  `base-xenial-i386.cow  base-bionic-i386.cow base-buster-i386.cow base-focal-i386.cow base-bullseye-i386.cow`
+  `base-bionic-i386.cow base-buster-i386.cow base-focal-i386.cow base-bullseye-i386.cow`
 
 - `UPDATE_EZBAKE_VERSION`
 

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -1,12 +1,12 @@
 ---
 default_cow: 'base-bionic-i386.cow'
-cows: 'base-xenial-i386.cow  base-bionic-i386.cow base-buster-i386.cow base-focal-i386.cow base-bullseye-i386.cow'
+cows: 'base-bionic-i386.cow base-buster-i386.cow base-focal-i386.cow base-bullseye-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_key: '4528B6CD9E61EF26'
 sign_tar: FALSE
 # a space separated list of mock configs
-final_mocks: 'pl-el-6-i386 pl-el-7-x86_64 pl-el-8-x86_64 pl-sles-12-x86_64 pl-sles-15-x86_64'
+final_mocks: 'pl-el-7-x86_64 pl-el-8-x86_64 pl-sles-12-x86_64 pl-sles-15-x86_64'
 yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: FALSE


### PR DESCRIPTION

Please add all notable changes to the "Unreleased" section of the CHANGELOG.