### PR TITLE
(PDB-5622) Fix EL java dependency on Platform 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.4.1] - 2023-04-06
+Bugfix:
+  * EL OSes depending on java 8 used the wrong package name
+
 ## [2.4.0] - 2023-04-06
 Added:
   * Add `puppet-platform-version` parameter, defaulting to 7, to allow EZBake

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -191,7 +191,7 @@ if options.output_type == 'rpm'
             '(java-17-openjdk-headless or java-11-openjdk-headless)'
           end
         when 6..7
-          'java-8-openjdk-headless'
+          'java-1.8.0-openjdk-headless'
         else
           fail "Unknown Puppet Platform Version #{options.platform_version}"
         end


### PR DESCRIPTION
This was mistakenly changed, it was previously getting the default from the top of fpm.rb
