### PR TITLE
(RE-15440,RE-15456) Add ubuntu 22.04 as a FOSS and PE server build target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+Added:
+  * (RE-15440,RE-15456) Add ubuntu 22.04 as a FOSS and PE server build target
 
 ## [2.4.1] - 2023-04-06
 Bugfix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [2.4.2] - 2023-04-06
 Added:
   * (RE-15440,RE-15456) Add ubuntu 22.04 as a FOSS and PE server build target
 
@@ -843,7 +845,10 @@ This release contains bug fixes and AIO path changes.
 ## 0.1.0 - 2015-01-13
  * Rewrite ezbake to follow leiningen plugin application model.
 
-[Unreleased]: https://github.com/puppetlabs/ezbake/compare/2.3.2...HEAD
+[Unreleased]: https://github.com/puppetlabs/ezbake/compare/2.4.2...HEAD
+[2.3.2]: https://github.com/puppetlabs/ezbake/compare/2.4.1...2.4.2
+[2.3.2]: https://github.com/puppetlabs/ezbake/compare/2.4.0...2.4.1
+[2.3.2]: https://github.com/puppetlabs/ezbake/compare/2.3.2...2.4.0
 [2.3.2]: https://github.com/puppetlabs/ezbake/compare/2.3.1...2.3.2
 [2.3.1]: https://github.com/puppetlabs/ezbake/compare/2.3.0...2.3.1
 [2.3.0]: https://github.com/puppetlabs/ezbake/compare/2.2.4...2.3.0

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -1,6 +1,6 @@
 ---
 default_cow: 'base-bionic-i386.cow'
-cows: 'base-bionic-i386.cow base-buster-i386.cow base-focal-i386.cow base-bullseye-i386.cow'
+cows: 'base-bionic-i386.cow base-buster-i386.cow base-focal-i386.cow base-bullseye-i386.cow base-jammy-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_key: '4528B6CD9E61EF26'

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
@@ -1,6 +1,6 @@
 ---
 default_cow: 'base-bionic-amd64.cow'
-cows: 'base-bionic-amd64.cow base-focal-amd64.cow'
+cows: 'base-bionic-amd64.cow base-focal-amd64.cow base-jammy-amd64.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppet'
 gpg_key: '4528B6CD9E61EF26'


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.