### PR TITLE
(maint) add tzdata-java as dependency on el-7 and above platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [2.5.2] - 2023-07-24
+Added:
  * add tzdata-java as an explicit dependency for FOSS projects with el7 and above as it was removed from openjdk
 
 ## [2.5.1] - 2023-07-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+ * add tzdata-java as an explicit dependency for FOSS projects with el7 and above as it was removed from openjdk
+
 ## [2.5.1] - 2023-07-21
 Added:
  * Add el-9 as a FOSS and PE server build target

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -181,6 +181,7 @@ if options.output_type == 'rpm'
     options.systemd_el = 1
   elsif options.operating_system == :el && options.os_version >= 7 # systemd el
     if ! options.is_pe
+      fpm_opts << "--depends tzdata-java"
       options.java =
         case options.platform_version
         when 8


### PR DESCRIPTION
With the release of openjdk-headless 11.0.20.0.8-2.el8 tzdata-java is no longer included as a dependency of openjdk. This causes startup failures in puppetserver when it isn't present.  This adds an explicit dependency on the package, which is small, and is required.

