### PR TITLE
(maint) Fix el9 platform 8 builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.5.3] - 2023-08-03
+Bugfix:
+ * Specify a java dependency on el9 when building for Puppet Platform 8
+
 ## [2.5.2] - 2023-07-24
 Added:
  * add tzdata-java as an explicit dependency for FOSS projects with el7 and above as it was removed from openjdk

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -190,6 +190,8 @@ if options.output_type == 'rpm'
             'java-11-openjdk-headless'
           elsif options.os_version == 8
             '(java-17-openjdk-headless or java-11-openjdk-headless)'
+          elsif options.os_version == 9
+            'java-17-openjdk-headless'
           else
             fail "Unrecognized el os version #{options.os_version}"
           end

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -190,6 +190,8 @@ if options.output_type == 'rpm'
             'java-11-openjdk-headless'
           elsif options.os_version == 8
             '(java-17-openjdk-headless or java-11-openjdk-headless)'
+          else
+            fail "Unrecognized el os version #{options.os_version}"
           end
         when 6..7
           'java-1.8.0-openjdk-headless'


### PR DESCRIPTION
Previously we were silently failing to specify a java dependency for Puppet Platform 8 builds on RedHat 9.

Add an error message that should help diagnose this issue for future redhat releases, and specify java 17 as a package dependency.