### PR TITLE
(PE-36861) Add a needrestart conf file for debian packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+Added:
+  * Drop a file in /etc/needrestart/conf.d for deb packages that add the service to the blocklist
 
 ## [2.5.3] - 2023-08-03
 Bugfix:

--- a/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
@@ -36,6 +36,8 @@ templates:
     target: ext/{{{project}}}.logrotate-legacy.conf
   - source: ext/ezbake.tmpfiles.conf.erb
     target: ext/{{{project}}}.tmpfiles.conf
+  - source: ext/ezbake.needrestart.conf.erb
+    target: ext/{{{project}}}.needrestart.conf
   - ext/redhat/preinst.erb
   - ext/redhat/postinst.erb
   - ext/redhat/prerm.erb

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake.needrestart.conf.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake.needrestart.conf.erb
@@ -1,0 +1,1 @@
+$nrconf{blacklist_rc} = [qr(^<%= EZBake::Config[:project] -%>)]

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -34,6 +34,7 @@ dest_apps_dir="${DESTDIR}${app_prefix}"
 app_data=${app_data:=/opt/puppetlabs/server/data/${real_name}}
 app_logdir=${app_logdir:=/var/log/puppetlabs/${real_name}}
 system_config_dir=${system_config_dir:=${app_prefix}/config}
+needrestart_confdir=${needrestart_dir:=/etc/needrestart/conf.d}
 
 
 ##################
@@ -294,6 +295,8 @@ function task_systemd_deb {
     fi
     install -d -m 0755 "${DESTDIR}${tmpfilesdir}"
     install -m 0644 ext/<%= EZBake::Config[:project] %>.tmpfiles.conf "${DESTDIR}${tmpfilesdir}/<%= EZBake::Config[:project] %>.conf"
+    install -d -m 0755 "${DESTDIR}${needrestart_confdir}"
+    install -m 0644 ext/<%= EZBake::Config[:project] %>.needrestart.conf "${DESTDIR}${needrestart_confdir}/<%= EZBake::Config[:project] %>.conf"
 }
 
 function task_service_account {


### PR DESCRIPTION
In Ubuntu 22, needrestart is now called by default whenever a package is installed via apt. Because our packages lay down a temp directory for use by the service, when the services create and modify files in those temp dirs, needrestart thinks the service needs to be restarted. Because we manage restarting our services as needed, this drops a file in /etc/needrestart/conf.d that adds the service to the list of services needrestart should ignore.

Note that this will drop the file regardless of if needrestart is present on the system (e.g. Ubuntu 18), but it should be harmless if needrestart isn't present.