### PR TITLE
Use PrivateTmp=true on systemd services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+Added:
+  * Use systemd's PrivateTmp feature for improved security
+
 Bugfix:
   * Fix java dependency on SLES 15 when building Puppet Platform 7
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
@@ -27,6 +27,7 @@ TimeoutStopSec=<%= EZBake::Config[:stop_timeout] %>
 Restart=on-failure
 StartLimitBurst=5
 PIDFile=/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>.pid
+PrivateTmp=true
 
 # https://tickets.puppetlabs.com/browse/EZ-129
 # Prior to systemd v228, TasksMax was unset by default, and unlimited. Starting in 228 a default of '512'

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
@@ -27,6 +27,7 @@ TimeoutStopSec=<%= EZBake::Config[:stop_timeout] %>
 Restart=on-failure
 StartLimitBurst=5
 PIDFile=/run/puppetlabs/<%= EZBake::Config[:real_name] %>/<%= EZBake::Config[:real_name] %>.pid
+PrivateTmp=true
 
 # https://tickets.puppetlabs.com/browse/EZ-129
 # Prior to systemd v228, TasksMax was unset by default, and unlimited. Starting in 228 a default of '512'


### PR DESCRIPTION
Using a private tmp directory improves security.