### PR TITLE
systemd service units: remove obsolete `StandardOutput=syslog`

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
@@ -60,7 +60,5 @@ ExecStartPost=-<%= action %>
 <% end -%>
 SuccessExitStatus=143
 
-StandardOutput=syslog
-
 [Install]
 WantedBy=multi-user.target

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
@@ -60,7 +60,5 @@ ExecStartPost=-<%= action %>
 <% end -%>
 SuccessExitStatus=143
 
-StandardOutput=syslog
-
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
`StandardOutput=syslog` has been obsolete since systemd 246 and produces warnings when used.