### PR TITLE
(maint) adjust sles java requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
+## [Unreleased]
+Bugfix:
+  * Fix java dependency on SLES 15 when building Puppet Platform 7
+
 ## [2.5.5]
 Bugfix:
   * Fix for needrestart conf file

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -220,7 +220,11 @@ if options.output_type == 'rpm'
         when 8
           'java-11-openjdk-headless'
         when 6..7
-          'java-1_8_0-openjdk-headless'
+          if options.os_version > 12
+            'java-11-openjdk-headless'
+          else
+            'java-1_8_0-openjdk-headless'
+          end
         else
           fail "Unknown Puppet Platform Version #{options.platform_version}"
         end


### PR DESCRIPTION
currently puppetserver 7 is not installable on sles > 12 because java 8 is no longer shipped with the OS.