### PR TITLE
Use virtual Java packages on Red Hat and set java_bin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject puppetlabs/lein-ezbake "2.6.3-SNAPSHOT"
+(defproject openvox/lein-ezbake "2.6.3-SNAPSHOT"
   :description "A system for building packages for trapperkeeper-based applications"
-  :url "https://github.com/puppetlabs/ezbake"
+  :url "https://github.com/openvoxproject/ezbake"
   :license {:name "Apache License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
@@ -15,11 +15,11 @@
                  ["snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-snapshots__local/"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
-                                     :username :env/clojars_jenkins_username
-                                     :password :env/clojars_jenkins_password
+                                     :username :env/clojars_username
+                                     :password :env/clojars_password
                                      :sign-releases false}]]
 
-  :scm {:name "git" :url "https://github.com/puppetlabs/ezbake"}
+  :scm {:name "git" :url "https://github.com/openvoxproject/ezbake"}
 
   :resource-paths ["resources/"]
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject openvox/lein-ezbake "2.6.3-SNAPSHOT"
+(defproject puppetlabs/lein-ezbake "2.6.3-SNAPSHOT-openvox"
   :description "A system for building packages for trapperkeeper-based applications"
   :url "https://github.com/openvoxproject/ezbake"
   :license {:name "Apache License 2.0"

--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -5,6 +5,7 @@ module EZBake
       :release        => {{{packaging-release}}},
       :platform_version => {{{puppet-platform-version}}},
       :real_name      => {{{real-name}}},
+      :package_name   => {{{package-name}}},
       :user           => {{{user}}},
       :numeric_uid_gid => {{{numeric-uid-gid}}},
       :group          => {{{group}}},

--- a/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
@@ -1,8 +1,8 @@
 ---
 project: '{{{project}}}'
-author: 'Puppet Labs'
-email: 'info@puppetlabs.com'
-homepage: 'https://github.com/puppetlabs/ezbake'
+author: 'Vox Pupuli'
+email: 'openvox@voxpupuli.org'
+homepage: 'https://github.com/openvoxproject/ezbake'
 summary: '{{{summary}}}'
 description: '{{{description}}}'
 version_file: 'version'

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
@@ -2,8 +2,8 @@
 # Init settings for <%= EZBake::Config[:project] %>
 ###########################################
 
-# Location of your Java binary (version 8)
-JAVA_BIN="/usr/bin/java"
+# Location of your Java binary
+JAVA_BIN="<%= EZBake::Config[:java_bin] %>"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
 JAVA_ARGS="<%= EZBake::Config[:java_args] %>"

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
@@ -3,7 +3,7 @@
 ###########################################
 
 # Location of your Java binary
-JAVA_BIN="<%= EZBake::Config[:java_bin] %>"
+#JAVA_BIN=""
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
 JAVA_ARGS="<%= EZBake::Config[:java_args] %>"

--- a/resources/puppetlabs/lein-ezbake/template/global/controller.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/controller.sh.erb
@@ -116,11 +116,11 @@ case $os in
 esac
 
 # bash will eat your spaces, so let's array. see http://mywiki.wooledge.org/BashFAQ/050 for more fun.
-params=("--user" "<%= EZBake::Config[:user] -%>" "--group" "<%= EZBake::Config[:group] -%>" "--chdir" "$dir" "--realname" "<%= EZBake::Config[:real_name] -%>" "--operating-system" "$os" "--name" "<%= EZBake::Config[:project] -%>" "--package-version" "<%= EZBake::Config[:version] -%>" "--release" "<%= EZBake::Config[:release] -%>" "--platform-version" "<%= EZBake::Config[:platform_version] -%>")
+params=("--user" "<%= EZBake::Config[:user] -%>" "--group" "<%= EZBake::Config[:group] -%>" "--chdir" "$dir" "--realname" "<%= EZBake::Config[:real_name] -%>" "--operating-system" "$os" "--name" "<%= EZBake::Config[:package_name] -%>" "--package-version" "<%= EZBake::Config[:version] -%>" "--release" "<%= EZBake::Config[:release] -%>" "--platform-version" "<%= EZBake::Config[:platform_version] -%>")
 if [ -n "$os_version" ]; then params+=("--os-version" "$os_version"); fi
 if [ -n "$os_dist" ]; then params+=("--dist" "$os_dist"); fi
 
-params+=('--description' "$(printf "Puppet Labs <%= EZBake::Config[:project] %>\nContains: <%= Pkg::Config.config[:description] -%>")")
+params+=('--description' "$(printf "Vox Pupuli <%= EZBake::Config[:project] %>\nContains: <%= Pkg::Config.config[:description] -%>")")
 
 <% unless EZBake::Config[:terminus_info].empty? -%>
 DESTDIR="$basepath/termini" bash install.sh termini

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.init.erb
@@ -22,6 +22,8 @@
 #set default privileges to -rw-r-----
 umask 027
 
+JAVA_BIN=<%= EZBake::Config[:java_bin] %>
+
 # You should only need to edit the default/<%= EZBake::Config[:project] %> file and not
 #   this init script directly
 if [ -r "/etc/default/<%= EZBake::Config[:project] %>" ] ; then

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.init.erb
@@ -17,7 +17,7 @@
 # Description:       Start <%= EZBake::Config[:project] %> daemon placed in /etc/init.d.
 ### END INIT INFO
 
-# Copyright 2014 Puppet Labs
+# Copyright 2014 Puppet Labs, 2025 Vox Pupuli
 
 #set default privileges to -rw-r-----
 umask 027
@@ -38,7 +38,7 @@ NAME=<%= EZBake::Config[:project] %>
 REALNAME=<%= EZBake::Config[:real_name] %>
 USER=<%= EZBake::Config[:user] %>
 GROUP=<%= EZBake::Config[:group] %>
-DESC="<%= EZBake::Config[:project] %> Puppet Labs version-checking backend"
+DESC="<%= EZBake::Config[:project] %> Vox Pupuli version-checking backend"
 JARFILE="<%= EZBake::Config[:uberjar_name] %>"
 PIDFILE=/run/puppetlabs/${REALNAME}/${REALNAME}.pid
 SCRIPTNAME=/etc/init.d/$NAME

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
@@ -20,6 +20,7 @@ Wants=<%= EZBake::Config[:start_after].map {|dep| "#{dep}.service" }.join(" ") %
 
 [Service]
 Type=forking
+Environment=JAVA_BIN="<%= EZBake::Config[:java_bin] %>"
 EnvironmentFile=/etc/default/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -14,6 +14,7 @@ options.old_el = 0
 options.old_sles = 0
 options.sles = 0
 options.java = 'java-1.8.0-openjdk-headless'
+options.java_bin = '/usr/bin/java'
 options.release = 1
 options.platform_version = 0
 options.is_pe = false

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -270,7 +270,7 @@ if options.output_type == 'rpm'
   end
 
   fpm_opts << "--config-files /etc/puppetlabs/#{options.realname}"
-  fpm_opts << "--config-files /etc/sysconfig/#{options.name}"
+  fpm_opts << "--config-files /etc/sysconfig/#{options.realname}"
 
   options.additional_dirs.each do |dir|
     fpm_opts << "--directories #{dir}"
@@ -282,7 +282,7 @@ if options.output_type == 'rpm'
   end
 
   if options.logrotate
-    fpm_opts << "--config-files /etc/logrotate.d/#{options.name}"
+    fpm_opts << "--config-files /etc/logrotate.d/#{options.realname}"
   end
 
   fpm_opts << "--directories #{options.app_logdir}"
@@ -366,16 +366,11 @@ termini_opts << "--name #{options.name}-termini"
 termini_opts << "--description '#{options.termini_description}'" unless options.termini_description.nil?
 shared_opts << "--version #{options.version}"
 shared_opts << "--iteration #{options.release}"
-shared_opts << "--vendor 'Puppet Labs <info@puppetlabs.com>'"
-shared_opts << "--maintainer 'Puppet Labs <info@puppetlabs.com>'"
+shared_opts << "--vendor 'Vox Pupuli <openvox@voxpupuli.org>'"
+shared_opts << "--maintainer 'Vox Pupuli <openvox@voxpupuli.org>'"
+shared_opts << "--license 'ASL 2.0'"
 
-if options.is_pe
-  shared_opts << "--license 'PL Commercial'"
-else
-  shared_opts << "--license 'ASL 2.0'"
-end
-
-shared_opts << "--url http://puppet.com"
+shared_opts << "--url http://github.com/openvoxproject"
 shared_opts << "--architecture all"
 
 options.replaces.each do |pkg, version|
@@ -384,8 +379,8 @@ options.replaces.each do |pkg, version|
     fpm_opts << "--conflicts '#{pkg} <= #{version}-1'"
   elsif options.output_type == 'deb'
     # why debian, why.
-    fpm_opts << "--replaces '#{pkg} (<< #{version}-1puppetlabs1)'"
-    fpm_opts << "--conflicts '#{pkg} (<< #{version}-1puppetlabs1)'"
+    fpm_opts << "--replaces '#{pkg} (<< #{version}-1openvox1)'"
+    fpm_opts << "--conflicts '#{pkg} (<< #{version}-1openvox1)'"
     fpm_opts << "--replaces '#{pkg} (<< #{version}-1#{options.dist})'"
     fpm_opts << "--conflicts '#{pkg} (<< #{version}-1#{options.dist})'"
   end
@@ -405,7 +400,7 @@ fpm_opts << "--depends /usr/bin/which" if options.output_type == 'rpm'
 fpm_opts << "--depends adduser" if options.output_type == 'deb'
 fpm_opts << "--depends procps"
 
-termini_opts << "--depends puppet-agent"
+termini_opts << "--depends openvox-agent"
 
 options.additional_dependencies.each do |dep|
   fpm_opts << "--depends '#{dep}'"

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -198,7 +198,7 @@ if options.output_type == 'rpm'
             'java-11-openjdk-headless'
           elsif options.os_version == 8
             '(java-17-openjdk-headless or java-11-openjdk-headless)'
-          elsif options.os_version == 9
+          elsif options.os_version >= 9
             'java-17-openjdk-headless'
           else
             fail "Unrecognized el os version #{options.os_version}"

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -332,7 +332,7 @@ if options.output_type == 'rpm'
 #deb specific options
 elsif options.output_type == 'deb'
   if options.dist != "#{options.operating_system}#{options.os_version}"
-    options.release = "#{options.release}#{options.dist}"
+    options.release = "#{options.release}+#{options.dist}"
   end
 
   if ! options.is_pe

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -204,7 +204,7 @@ if options.output_type == 'rpm'
             fail "Unrecognized el os version #{options.os_version}"
           end
         when 7
-          'java-1.8.0-openjdk-headless'
+          'java-11-openjdk-headless'
         else
           fail "Unknown Puppet Platform Version #{options.platform_version}"
         end

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -190,16 +190,20 @@ if options.output_type == 'rpm'
     options.systemd_el = 1
   elsif options.operating_system == :el && options.os_version >= 7 # systemd el
     if ! options.is_pe
+      # https://bugzilla.redhat.com/show_bug.cgi?id=2224427
       fpm_opts << "--depends tzdata-java"
       case options.platform_version
       when 8
         # rpm on Redhat 7 may not support OR dependencies
         if options.os_version == 7
-          options.java = 'java-11-openjdk-headless'
+          options.java = 'jre-11-headless'
+          options.java_bin = '/usr/lib/jvm/jre-11/bin/java'
         elsif options.os_version == 8
-          options.java = '(java-17-openjdk-headless or java-11-openjdk-headless)'
+          options.java = '(jre-17-headless or jre-11-headless)'
+          # TODO: which bin to use? /usr/bin/java may be anything
         elsif options.os_version >= 9
-          'options.java = java-17-openjdk-headless'
+          options.java = 'jre-17-headless'
+          options.java_bin = '/usr/lib/jvm/jre-17/bin/java'
         else
           fail "Unrecognized el os version #{options.os_version}"
         end

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -191,24 +191,23 @@ if options.output_type == 'rpm'
   elsif options.operating_system == :el && options.os_version >= 7 # systemd el
     if ! options.is_pe
       fpm_opts << "--depends tzdata-java"
-      options.java =
-        case options.platform_version
-        when 8
-          # rpm on Redhat 7 may not support OR dependencies
-          if options.os_version == 7
-            'java-11-openjdk-headless'
-          elsif options.os_version == 8
-            '(java-17-openjdk-headless or java-11-openjdk-headless)'
-          elsif options.os_version >= 9
-            'java-17-openjdk-headless'
-          else
-            fail "Unrecognized el os version #{options.os_version}"
-          end
-        when 7
-          'java-11-openjdk-headless'
+      case options.platform_version
+      when 8
+        # rpm on Redhat 7 may not support OR dependencies
+        if options.os_version == 7
+          options.java = 'java-11-openjdk-headless'
+        elsif options.os_version == 8
+          options.java = '(java-17-openjdk-headless or java-11-openjdk-headless)'
+        elsif options.os_version >= 9
+          'options.java = java-17-openjdk-headless'
         else
-          fail "Unknown Puppet Platform Version #{options.platform_version}"
+          fail "Unrecognized el os version #{options.os_version}"
         end
+      when 7
+        options.java = 'java-11-openjdk-headless'
+      else
+        fail "Unrecognized el os version #{options.os_version}"
+      end
     end
 
     options.systemd = 1

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
@@ -20,6 +20,7 @@ Wants=<%= EZBake::Config[:start_after].map {|dep| "#{dep}.service" }.join(" ") %
 
 [Service]
 Type=forking
+Environment=JAVA_BIN="<%= EZBake::Config[:java_bin] %>"
 EnvironmentFile=/etc/sysconfig/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/init.erb
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# Puppet Labs <%= EZBake::Config[:project] %>
+# Vox Pupuli <%= EZBake::Config[:project] %>
 #
 # chkconfig: - 70 10
-# description: Puppet Labs <%= EZBake::Config[:project] %>
+# description: Vox Pupuli <%= EZBake::Config[:project] %>
 
 ### BEGIN INIT INFO
 # Provides:          <%= EZBake::Config[:project] %>
@@ -23,7 +23,7 @@
 # Description:       Start <%= EZBake::Config[:project] %> daemon placed in /etc/init.d.
 ### END INIT INFO
 
-# Copyright 2014 Puppet Labs
+# Copyright 2014 Puppet Labs, 2025 Vox Pupuli
 
 # Source function library.
 . /etc/rc.d/init.d/functions

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/init.suse.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/init.suse.erb
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# Puppet Labs <%= EZBake::Config[:project] %>
+# Vox Pupuli <%= EZBake::Config[:project] %>
 #
 # chkconfig: - 70 10
-# description: Puppet Labs <%= EZBake::Config[:project] %>
+# description: Vox Pupuli <%= EZBake::Config[:project] %>
 
 ### BEGIN INIT INFO
 # Provides:          <%= EZBake::Config[:project] %>
@@ -23,7 +23,7 @@
 # Description:       Start <%= EZBake::Config[:project] %> daemon placed in /etc/init.d.
 ### END INIT INFO
 
-# Copyright 2014 Puppet Labs
+# Copyright 2014 Puppet Labs, 2025 Vox Pupuli
 
 # Source function library.
 [ -e /lib/lsb/init-functions ] && . /lib/lsb/init-functions

--- a/resources/puppetlabs/lein-ezbake/template/global/tasks/build.rake
+++ b/resources/puppetlabs/lein-ezbake/template/global/tasks/build.rake
@@ -82,7 +82,7 @@ namespace :pl do
         stdout, stderr, exitstatus = Pkg::Util::Execution.capture3(%(bash controller.sh debian #{platform} #{staging_path}))
         Pkg::Util::Execution.success?(exitstatus) or raise "Error running packaging: #{stdout}\n#{stderr}"
         puts "#{stdout}\n#{stderr}"
-        FileUtils.cp(Dir.glob("*#{platform}*.deb"), "#{pkg_path}/#{platform_path}")
+        FileUtils.cp(Dir.glob("*.deb"), "#{pkg_path}/#{platform_path}")
       end
       FileUtils.cp_r(pkg_path, nested_output)
       FileUtils.rm_r(staging_path)

--- a/resources/puppetlabs/lein-ezbake/template/global/tasks/build.rake
+++ b/resources/puppetlabs/lein-ezbake/template/global/tasks/build.rake
@@ -82,7 +82,7 @@ namespace :pl do
         stdout, stderr, exitstatus = Pkg::Util::Execution.capture3(%(bash controller.sh debian #{platform} #{staging_path}))
         Pkg::Util::Execution.success?(exitstatus) or raise "Error running packaging: #{stdout}\n#{stderr}"
         puts "#{stdout}\n#{stderr}"
-        FileUtils.cp(Dir.glob("*.deb"), "#{pkg_path}/#{platform_path}")
+        FileUtils.cp(Dir.glob("*#{platform}*.deb"), "#{pkg_path}/#{platform_path}")
       end
       FileUtils.cp_r(pkg_path, nested_output)
       FileUtils.rm_r(staging_path)

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -74,6 +74,7 @@
    (schema/optional-key :group) schema/Str
    (schema/optional-key :puppet-platform-version) schema/Int
    (schema/optional-key :bootstrap-source) BootstrapSource
+   (schema/optional-key :package-name) schema/Str
    (schema/optional-key :create-dirs) [schema/Str]
    (schema/optional-key :build-type) schema/Str
    (schema/optional-key :reload-timeout) schema/Int
@@ -263,7 +264,7 @@
     (spit
      (fs/file staging-dir "ext" "ezbake.manifest")
      (stencil/render-string "
-This package was built by the Puppet Labs packaging system.
+This package was built by the OpenVox packaging system.
 
 EZBake version: {{{ezbake-version}}}
 Release package: {{{package-group}}}/{{{package-name}}} ({{{package-version}}})
@@ -594,6 +595,8 @@ Additional uberjar dependencies:
         get-local #(get-local-ezbake-var lein-project %1 %2)
         local->ruby #(as-ruby-literal (get-local %1 %2))]
     {:project                            (as-ruby-literal (:name lein-project))
+     :package-name                       (as-ruby-literal (-> (get-in lein-project [:lein-ezbake :vars :package-name])
+                                              (or (:name lein-project))))
      :packaging-version                  (-> (:version lein-project)
                                              generate-package-version-from-version
                                              as-ruby-literal)


### PR DESCRIPTION
This uses the virtual packages jre-VERSION-headless instead of explicitly openjdk. This allows other JREs to provide the same.

It also uses an explicit path to the JRE specific java bin. At least on EL9 this allows the following upgrade path to work:

    dnf install https://yum.puppet.com/puppet7-release-el-9.noarch.rpm
    dnf install puppetserver
    dnf install https://yum.puppet.com/puppet8-release-el-9.noarch.rpm
    dnf upgrade puppetserver

Prior to this patch it would break, because it used /usr/bin/java which will point to Java 8. By using /usr/lib/jvm/jre-17/bin/java we know for sure it is Java 17.