### PR TITLE
(bugfix) rpm install-time macro expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+* Use RPM install-time macro expansion in scriptlets
 * Add AmazonLinux 2023 as a FOSS build target
 * Drop platform 6 fpm support
 * On all Debian platforms simplify java depends, allow 17 or 11, prefer 17

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -169,6 +169,7 @@ options.app_data = "/opt/puppetlabs/server/data/#{options.realname}"
 # rpm specific options
 if options.output_type == 'rpm'
 
+  shared_opts << "--rpm-macro-expansion"
   shared_opts << "--rpm-digest sha256"
   shared_opts << "--rpm-rpmbuild-define 'rpmversion #{options.version}'"
   fpm_opts << "--rpm-rpmbuild-define '_app_logdir #{options.app_logdir}'"
@@ -263,6 +264,7 @@ if options.output_type == 'rpm'
 
   if options.systemd_el == 1
     fpm_opts << "--depends systemd"
+    fpm_opts << "--depends systemd-rpm-macros"
   end
 
   if options.systemd_sles == 1


### PR DESCRIPTION
Fpm does not support build-time dependencies because it's a cross-platform package builder. The rpm scriptlet macros we use will not expand consistently, or at all, depending on the host being used to build a package.