### PR TITLE
(PE-39585) Add Ubuntu 24 and Amazon support to PE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [2.7.0]
+* Add AmazonLinux 2023 as PE build target
+* Add Ubuntu 24.04 as PE & FOSS build target
 * Add AmazonLinux 2023 as a FOSS build target
+
+## [2.6.2]
 * Drop platform 6 fpm support
 * On all Debian platforms simplify java depends, allow 17 or 11, prefer 17
 * Add Debian 12 bookworm as a FOSS build target

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/lein-ezbake "2.6.3-SNAPSHOT"
+(defproject puppetlabs/lein-ezbake "2.7.0-SNAPSHOT"
   :description "A system for building packages for trapperkeeper-based applications"
   :url "https://github.com/puppetlabs/ezbake"
   :license {:name "Apache License 2.0"

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/build_defaults.yaml
@@ -1,6 +1,6 @@
 ---
-default_cow: 'base-bionic-i386.cow'
-cows: 'base-bionic-i386.cow base-buster-i386.cow base-focal-i386.cow base-bullseye-i386.cow base-jammy-i386.cow base-bookworm-i386.cow'
+default_cow: 'base-jammy-i386.cow'
+cows: 'base-bionic-i386.cow base-buster-i386.cow base-focal-i386.cow base-bullseye-i386.cow base-jammy-i386.cow base-bookworm-i386.cow base-noble-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_key: '4528B6CD9E61EF26'

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
@@ -1,6 +1,6 @@
 ---
-default_cow: 'base-bionic-amd64.cow'
-cows: 'base-bionic-amd64.cow base-focal-amd64.cow base-jammy-amd64.cow'
+default_cow: 'base-jammy-amd64.cow'
+cows: 'base-bionic-amd64.cow base-focal-amd64.cow base-jammy-amd64.cow base-noble-amd64.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppet'
 gpg_key: '4528B6CD9E61EF26'

--- a/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
+++ b/resources/puppetlabs/lein-ezbake/template/pe/ext/build_defaults.yaml
@@ -6,7 +6,7 @@ packager: 'puppet'
 gpg_key: '4528B6CD9E61EF26'
 sign_tar: FALSE
 # a space separated list of mock configs
-final_mocks: 'pupent-el7-x86_64 pupent-el8-x86_64 pupent-el9-x86_64 pupent-redhatfips7-x86_64 pupent-redhatfips8-x86_64 pupent-sles12-x86_64 pupent-sles15-x86_64'
+final_mocks: 'pupent-el7-x86_64 pupent-el8-x86_64 pupent-el9-x86_64 pupent-redhatfips7-x86_64 pupent-redhatfips8-x86_64 pupent-sles12-x86_64 pupent-sles15-x86_64 pupent-amazon-2023-x86_64'
 yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: FALSE


### PR DESCRIPTION
DNM - I believe that the `pupent-amazon-2023-x86_64` but not sure yet.